### PR TITLE
Fix double-free of CSRectGrid

### DIFF
--- a/python/CSXCAD/CSRectGrid.pxd
+++ b/python/CSXCAD/CSRectGrid.pxd
@@ -52,4 +52,5 @@ cdef extern from "CSXCAD/CSRectGrid.h":
             bool isValid()
 
 cdef class CSRectGrid:
-    cdef  _CSRectGrid *thisptr
+    cdef _CSRectGrid *thisptr
+    cdef bool no_init

--- a/python/CSXCAD/CSRectGrid.pyx
+++ b/python/CSXCAD/CSRectGrid.pyx
@@ -34,6 +34,7 @@ cdef class CSRectGrid:
     :param CoordSystem: define the coordinate system (default 0 : Cartesian)
     """
     def __cinit__(self, *args, no_init=False, **kw):
+        self.no_init = no_init
         if no_init==False:
             self.thisptr = new _CSRectGrid()
             if 'CoordSystem' in kw:
@@ -48,7 +49,8 @@ cdef class CSRectGrid:
         assert len(kw)==0, 'Unknown keyword arguments: "{}"'.format(kw)
 
     def __dealloc__(self):
-        del self.thisptr
+        if not self.no_init:
+            del self.thisptr
 
     def SetMeshType(self, cs_type):
         """ SetMeshType(cs_type)

--- a/python/CSXCAD/CSXCAD.pyx
+++ b/python/CSXCAD/CSXCAD.pyx
@@ -90,8 +90,6 @@ cdef class ContinuousStructure:
         assert len(kw)==0, 'Unknown keyword arguments: "{}"'.format(kw)
 
     def __dealloc__(self):
-        self.__grid.thisptr = NULL
-        self.__paraset.thisptr = NULL
         del self.thisptr
 
     def Update(self):

--- a/python/CSXCAD/ParameterObjects.pxd
+++ b/python/CSXCAD/ParameterObjects.pxd
@@ -26,3 +26,4 @@ cdef extern from "CSXCAD/ParameterObjects.h":
 
 cdef class ParameterSet:
     cdef _ParameterSet *thisptr
+    cdef bool no_init

--- a/python/CSXCAD/ParameterObjects.pyx
+++ b/python/CSXCAD/ParameterObjects.pyx
@@ -23,11 +23,12 @@ cimport ParameterObjects
 
 cdef class ParameterSet:
     def __cinit__(self, no_init=False):
+        self.no_init = no_init
         if no_init==True:
             self.thisptr = NULL
         else:
             self.thisptr = new _ParameterSet()
 
-#    def __dealloc__(self):
-#        del self.thisptr
-#        self.thisptr = NULL
+    def __dealloc__(self):
+        if not self.no_init:
+            del self.thisptr


### PR DESCRIPTION
ContinuousStructure.\_\_cinit\_\_ creates an instance of CSRectGrid that does not
own its contents, then tries to prevent it from freeing its contents by
nulling its thisptr in ContinuousStructure.\_\_dealloc\_\_.

However, when reference cycles exist, ContinuousStructure.\_\_dealloc\_\_ is not
guaranteed to be called before CSRectGrid.\_\_dealloc\_\_, since the garbage
collector may call ContinuousStructure's tp_clear function (which frees the
CSRectGrid instance).