### PR TITLE
Cast the return type of numpy.ceil to an integer type as numpy 0.18 l…

### DIFF
--- a/python/CSXCAD/SmoothMeshLines.py
+++ b/python/CSXCAD/SmoothMeshLines.py
@@ -62,7 +62,7 @@ def SmoothRange(start, stop, start_res, stop_res, max_res, ratio):
 
     # very large range and easy start/stop res
     if start_res>=(max_res/ratio) and stop_res>=(max_res/ratio):
-        N = np.ceil(rng/max_res)
+        N = np.ceil(rng/max_res).astype('int')
         return np.linspace(start, stop, N+1)
 
     def one_side_taper(start_res, ratio, max_res):


### PR DESCRIPTION
…inspace has now fully deprecated previously warned behaviour for floats used as step size
