### PR TITLE
tinyxml looks for FileName, not Filename during xml read

### DIFF
--- a/src/CSPrimPolyhedronReader.cpp
+++ b/src/CSPrimPolyhedronReader.cpp
@@ -66,7 +66,7 @@ bool CSPrimPolyhedronReader::Update(std::string *ErrStr)
 
 bool CSPrimPolyhedronReader::Write2XML(TiXmlElement &elem, bool parameterised)
 {
-	elem.SetAttribute("Filename",m_filename);
+	elem.SetAttribute("FileName",m_filename);
 
 	switch (m_filetype)
 	{


### PR DESCRIPTION
Very simple fix: polyhedron reader writes the filename attribute as Filename and tries to read it as FileName. Let me know if any concerns/etc.