### PR TITLE
compute proper bounding box for cylinders

### DIFF
--- a/src/CSPrimCylinder.h
+++ b/src/CSPrimCylinder.h
@@ -19,6 +19,10 @@
 
 #include "CSPrimitives.h"
 
+#define PI 3.141592653589793238462643383279
+
+void NormalizeVector(double *vec);
+
 //! Cylinder Primitive
 /*!
  This is a cylindrical primitive defined by its axis start-, end-coordinates and a radius.
@@ -62,4 +66,3 @@ protected:
 	ParameterCoord m_AxisCoords[2];
 	ParameterScalar psRadius;
 };
-

--- a/src/CSPrimCylindricalShell.cpp
+++ b/src/CSPrimCylindricalShell.cpp
@@ -60,40 +60,118 @@ bool CSPrimCylindricalShell::GetBoundBox(double dBoundBox[6], bool PreserveOrien
 	const double* stop =m_AxisCoords[1].GetCartesianCoords();
 	m_BoundBox_CoordSys=CARTESIAN;
 	double rad=psRadius.GetValue()+psShellWidth.GetValue()/2.0;
-	for (unsigned int i=0;i<3;++i)
-	{
-		double min=start[i];
-		double max=stop[i];
-		if (min<max)
-		{
-			dBoundBox[2*i]=min-rad;
-			dBoundBox[2*i+1]=max+rad;
-		}
-		else
-		{
-			dBoundBox[2*i+1]=min+rad;
-			dBoundBox[2*i]=max-rad;
-		}
-		if (min==max) Direction+=pow(2,i);
-	}
-	switch (Direction)
-	{
-	case 3: //orientaion in z-direction
-		dBoundBox[4]=dBoundBox[4]+rad;
-		dBoundBox[5]=dBoundBox[5]-rad;
-		accurate=true;
-		break;
-	case 5: //orientaion in y-direction
-		dBoundBox[2]=dBoundBox[2]+rad;
-		dBoundBox[3]=dBoundBox[3]-rad;
-		accurate=true;
-		break;
-	case 6: //orientaion in x-direction
-		dBoundBox[1]=dBoundBox[1]+rad;
-		dBoundBox[2]=dBoundBox[2]-rad;
-		accurate=true;
-		break;
-	}
+        // unit vector in direction of cylinder axis
+        double v[3];
+        int vnonzero = -1;  // TODO handle zero-height cylinders
+        unsigned int zero_count = 0;
+        for (unsigned int i=0; i<3; ++i)
+        {
+                v[i] = stop[i] - start[i];
+                if (v[i] != 0)
+                {
+                        vnonzero = i;
+                }
+                else
+                {
+                        ++zero_count;
+                        Direction+=pow(2,i);
+                }
+        }
+
+        if (zero_count == 2)
+        {
+                bool flip = start[vnonzero] > stop[vnonzero];
+                for (unsigned int i=0; i<3; ++i)
+                {
+                        if (i == vnonzero)
+                        {
+                                if (!flip)
+                                {
+                                        dBoundBox[2*i] = start[i];
+                                        dBoundBox[2*i+1] = stop[i];
+                                }
+                                else
+                                {
+                                        dBoundBox[2*i] = stop[i];
+                                        dBoundBox[2*i+1] = start[i];
+                                }
+                        }
+                        else
+                        {
+                                if (!flip)
+                                {
+                                        dBoundBox[2*i] = -rad + start[i];
+                                        dBoundBox[2*i+1] = rad + start[i];
+                                }
+                                else
+                                {
+                                        dBoundBox[2*i] = rad + start[i];
+                                        dBoundBox[2*i+1] = -rad + start[i];
+                                }
+                        }
+                }
+        }
+        else
+        {
+                NormalizeVector(v);
+
+                // some unit vector perpendicular to cylinder axis
+                double a[3];
+                for (unsigned int i=0; i<3; ++i)
+                {
+                        if (i == vnonzero)
+                        {
+                                unsigned int i1 = (i + 1) % 3;
+                                unsigned int i2 = (i + 2) % 3;
+                                a[i] = (v[i1] + v[i2]) / v[i];
+                        }
+                        else
+                        {
+                                a[i] = -1;
+                        }
+                }
+                NormalizeVector(a);
+
+                // unit vector perpendicular to cylinder axis and a
+                double b[3] = {a[1]*v[2] - a[2]*v[1], -a[0]*v[2] + a[2]*v[0], a[0]*v[1] - a[1]*v[0]};
+
+                double theta[3];
+                for (unsigned int i=0; i<3; ++i)
+                {
+                        theta[i] = atan(b[i]/a[i]);
+                }
+
+                double min[3] = {start[0], start[1], start[2]};
+                double max[3] = {start[0], start[1], start[2]};
+
+                for (unsigned int i=0; i<2; ++i)
+                {
+                        const double* coord = m_AxisCoords[i].GetCartesianCoords();
+                        for (unsigned int j=0; j<3; ++j)
+                        {
+                                double val = coord[j] + rad*a[j]*cos(theta[j]) + rad*b[j]*sin(theta[j]);
+                                double val2 = coord[j] + rad*a[j]*cos(theta[j]+PI) + rad*b[j]*sin(theta[j]+PI);
+                                min[j] = fmin(min[j], val);
+                                min[j] = fmin(min[j], val2);
+                                max[j] = fmax(max[j], val);
+                                max[j] = fmax(max[j], val2);
+                        }
+                }
+
+                for (unsigned int i=0; i<3; ++i)
+                {
+                        if (start[i] <= stop[i])
+                        {
+                                dBoundBox[2*i]=min[i];
+                                dBoundBox[2*i+1]=max[i];
+                        }
+                        else
+                        {
+                                dBoundBox[2*i]=max[i];
+                                dBoundBox[2*i+1]=min[i];
+                        }
+                }
+        }
 
 	if (rad>0)
 		m_Dimension=3;


### PR DESCRIPTION
This PR computes a proper bounding box for cylinders and cylindrical shells. It does this by computing parametric equations for the terminal circles and then computing maxima and minima (parametric circle equations use the method described [here](https://math.stackexchange.com/a/73242/583981)).

Let me know what you think of this. Happy to make any/all changes needed. In particular, this won't handle zero-height cylinders correctly, although I'm not sure what the intended behavior is there. If you do have specific behavior in mind for that, let me know and I'll make this work with it.

Additionally, I'm not sure how to get the bounding box of transformed cylinders. Normally, I get the original bounding box of the object and then transform each coordinate, but that doesn't seem to work here. Any thoughts on how to do this?