### PR TITLE
Fix build with VTK 9.0, fix memory leak

### DIFF
--- a/src/CSPrimPolyhedronReader.cpp
+++ b/src/CSPrimPolyhedronReader.cpp
@@ -163,7 +163,7 @@ bool CSPrimPolyhedronReader::ReadFile()
 		AddVertex(polydata->GetPoint(n));
 
 	vtkIdType numP;
-	vtkIdType *vertices = new vtkIdType[10];
+	vtkIdType const *vertices = nullptr;
 	while (verts->GetNextCell(numP, vertices))
 	{
 		face f;


### PR DESCRIPTION
The vertices array contains immutable IDs, which is reflected by the
changed API in VTK 9.0.

As GetNextCell(numP, vertices) overwrites vertices (it is a reference),
the previously pointed to/acllocated array was leaked.