### PR TITLE
fix smoothmeshlines import

### DIFF
--- a/python/CSXCAD/CSRectGrid.pyx
+++ b/python/CSXCAD/CSRectGrid.pyx
@@ -23,7 +23,7 @@ Rectilinear Grid Class for CSXCAD
 import numpy as np
 cimport CSRectGrid
 from Utilities import CheckNyDir
-from SmoothMeshLines import SmoothMeshLines
+from CSXCAD.SmoothMeshLines import SmoothMeshLines
 
 cdef class CSRectGrid:
     """

--- a/python/CSXCAD/SmoothMeshLines.py
+++ b/python/CSXCAD/SmoothMeshLines.py
@@ -17,7 +17,6 @@
 #
 
 import numpy as np
-import pylab as plt
 
 def MeshLinesSymmetric(l, rel_tol=1e-6):
     """
@@ -237,6 +236,7 @@ def SmoothMeshLines(lines, max_res, ratio=1.5, **kw):
 
 if __name__ == "__main__":
 
+    import pylab as plt
 #    print(SmoothRange(0., 1., 10., 50., 25., 1.5))
 #    print(SmoothRange(0., 100., 1., 50., 25., 1.5))
 #    print(SmoothRange(0., 100., 50., 1., 25., 1.5))


### PR DESCRIPTION
setup.py only installs the CSXCAD package, and SmoothMeshLines is a
part of this. It is not available as a simple `import
SmoothMeshLines`.

pylab is deprecated and only used when running SmoothMeshLines.py
directly, which is a rare use-case. Therefore, it makes more sense to
import pylab only when it is needed.