### PR TITLE
Fix double free regression, fix leak

### DIFF
--- a/src/CSPrimPolyhedronReader.cpp
+++ b/src/CSPrimPolyhedronReader.cpp
@@ -163,10 +163,10 @@ bool CSPrimPolyhedronReader::ReadFile()
 		AddVertex(polydata->GetPoint(n));
 
 	vtkIdType numP;
-#if VTK_MAJOR_VERSION>=9
-	const vtkIdType *vertices = new vtkIdType[10];
+#if VTK_CELL_ARRAY_V2
+	const vtkIdType *vertices = nullptr;
 #else
-	vtkIdType *vertices = new vtkIdType[10];
+	vtkIdType *vertices = nullptr;
 #endif
 	while (verts->GetNextCell(numP, vertices))
 	{
@@ -177,6 +177,5 @@ bool CSPrimPolyhedronReader::ReadFile()
 			f.vertices[np]=vertices[np];
 		AddFace(f);
 	}
-	delete vertices;
 	return true;
 }

--- a/src/CSPrimPolyhedronReader.cpp
+++ b/src/CSPrimPolyhedronReader.cpp
@@ -168,6 +168,7 @@ bool CSPrimPolyhedronReader::ReadFile()
 #else
 	vtkIdType *vertices = nullptr;
 #endif
+	verts->InitTraversal();
 	while (verts->GetNextCell(numP, vertices))
 	{
 		face f;


### PR DESCRIPTION
The call to GetNextCell changes the address which vertices refers to,
to some address in VTKs array data structures. After the call the address
of the vtkIdType[10] heap allocated array is lost.

The later call to delete causes a double-free, invalidating some of the
internal VTK array data structure.

Use VTK_CELL_ARRAY_V2 as guard for VTK9 (as suggested by VTKs
documentation).