### PR TITLE
Fix CSPrimPolyhedronReader : align ReadFromXML 'FileName' field to Write2XML 'Filename' spelling

### DIFF
--- a/src/CSPrimPolyhedronReader.cpp
+++ b/src/CSPrimPolyhedronReader.cpp
@@ -89,7 +89,7 @@ bool CSPrimPolyhedronReader::ReadFromXML(TiXmlNode &root)
 
 	TiXmlElement* elem=root.ToElement();
 	if (elem==NULL) return false;
-	if (elem->QueryStringAttribute("FileName",&m_filename)!=TIXML_SUCCESS)
+	if (elem->QueryStringAttribute("Filename",&m_filename)!=TIXML_SUCCESS)
 	{
 		std::cerr << "CSPrimPolyhedronReader::ReadFromXML: Error, can't read filename!" << std::endl;
 		return false;


### PR DESCRIPTION
There is an inconsist spelling of the filename field in the `CSPrimPolyhedronReader` write and read functions ([`"Filename"`](https://github.com/thliebig/CSXCAD/blob/3c4fb665d934349e048fbcc31d6be203483b5e98/src/CSPrimPolyhedronReader.cpp#L69) vs [`"FileName"`](https://github.com/thliebig/CSXCAD/blob/3c4fb665d934349e048fbcc31d6be203483b5e98/src/CSPrimPolyhedronReader.cpp#L92), respectively) that cause problems in [pyems](https://github.com/matthuszagh/pyems) usage.

@Matthuszagh [proposed a fix](https://github.com/thliebig/CSXCAD/commit/c14eb8441e71f81beb4ab96119be7bd184b3ed7a) by aligning the `Write2XML` spelling to the `ReadFromXML` one.

It obviously broke something somewhere else since you [revert it](https://github.com/thliebig/CSXCAD/commit/3c4fb665d934349e048fbcc31d6be203483b5e98).

So maybe we could instead align the `ReadFromXML` spelling to the `Write2XML` one.