### PR TITLE
CMakeLists: fix handling cxxflags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ PROJECT(CSXCAD CXX C)
 cmake_minimum_required(VERSION 3.0)
 
 if (NOT WIN32)
- set (CMAKE_CXX_FLAGS -fPIC )
+ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()
 
 # default


### PR DESCRIPTION
Currently CMakeLists overwrites cxxflags, which can break the build. Respect `CMAKE_CXX_FLAGS`, if passed.