### PR TITLE
Add check that file exists to `AddPolyhedronReader`

### DIFF
--- a/python/CSXCAD/CSPrimitives.pyx
+++ b/python/CSXCAD/CSPrimitives.pyx
@@ -1256,6 +1256,11 @@ cdef class CSPrimPolyhedronReader(CSPrimPolyhedron):
         Issue to read the file.
 
         :return succ: bool -- True on successful read
+
+        :raises RuntimeError: If it is not possible to read the file, for whatever reason.
         """
         ptr = <_CSPrimPolyhedronReader*>self.thisptr
-        return ptr.ReadFile()
+        success = ptr.ReadFile()
+        if success != True:
+            raise RuntimeError(f'Cannot read file {self.GetFilename().decode()}. Check file name, file location, or its content.')
+        return success

--- a/python/CSXCAD/CSProperties.pyx
+++ b/python/CSXCAD/CSProperties.pyx
@@ -40,6 +40,7 @@ cimport CSXCAD.CSProperties
 cimport CSXCAD.CSPrimitives as c_CSPrimitives
 from CSXCAD.CSPrimitives import CSPrimitives
 from CSXCAD.Utilities import CheckNyDir
+from pathlib import Path
 
 def hex2color(color):
     if color.startswith('#'):
@@ -388,16 +389,23 @@ cdef class CSProperties:
         """
         return self.__CreatePrimitive(c_CSPrimitives.POLYHEDRON, **kw)
 
-    def AddPolyhedronReader(self, filename, **kw):
+    def AddPolyhedronReader(self, path_to_file:Path|str, **kw):
         """ AddPolyhedronReader(filename, **kw)
 
         Add a polyhedron from file to this property.
+
+        Arguments
+        ---------
+        path_to_file : Path or str
+            The path to the file containing the geometry.
 
         See Also
         --------
         CSXCAD.CSPrimitives.CSPrimPolyhedronReader : See here for details on primitive arguments
         """
-        return self.__CreatePrimitive(c_CSPrimitives.POLYHEDRONREADER, filename=filename, **kw)
+        path_to_file = Path(path_to_file) # Check that we can interpret this as a path.
+        path_to_file.resolve(strict=True) # Check that file exists, raise error otherwise.
+        return self.__CreatePrimitive(c_CSPrimitives.POLYHEDRONREADER, filename=path_to_file.name, **kw)
 
     def __CreatePrimitive(self, prim_type, **kw):
         pset = self.GetParameterSet()
@@ -607,13 +615,13 @@ cdef class CSPropLumpedElement(CSProperties):
     :param LEtype:  int      -- lumped element type
     """
     def __init__(self, ParameterSet pset, *args, no_init=False, **kw):
-                
+
         if no_init:
             self.thisptr = NULL
             return
         if not self.thisptr:
             self.thisptr = <_CSProperties*> new _CSPropLumpedElement(pset.thisptr)
-        
+
         b_LEtype_found = False
         for k in kw:
             if k=='R':
@@ -630,11 +638,11 @@ cdef class CSPropLumpedElement(CSProperties):
                 b_LEtype_found = True
                 # Consider adding some logic here, to prevent silly errors. Default parallel and all that
                 self.SetLEtype(kw[k])
-        
-        # If the lumped element type is not found, assume parallel 
+
+        # If the lumped element type is not found, assume parallel
         if (not b_LEtype_found):
             self.SetLEtype(LE_PARALLEL)
-            
+
         for k in ['R', 'L', 'C', 'ny', 'caps','LEtype']:
             if k in kw:
                 del kw[k]
@@ -695,7 +703,7 @@ cdef class CSPropLumpedElement(CSProperties):
         """ SetLEtype(val)
         """
         (<_CSPropLumpedElement*>self.thisptr).SetLEtype(val)
-        
+
     def GetLEtype(self):
         """ GetLEtype()
         """

--- a/python/CSXCAD/CSProperties.pyx
+++ b/python/CSXCAD/CSProperties.pyx
@@ -389,23 +389,16 @@ cdef class CSProperties:
         """
         return self.__CreatePrimitive(c_CSPrimitives.POLYHEDRON, **kw)
 
-    def AddPolyhedronReader(self, path_to_file:Path|str, **kw):
+    def AddPolyhedronReader(self, filename, **kw):
         """ AddPolyhedronReader(filename, **kw)
 
         Add a polyhedron from file to this property.
-
-        Arguments
-        ---------
-        path_to_file : Path or str
-            The path to the file containing the geometry.
 
         See Also
         --------
         CSXCAD.CSPrimitives.CSPrimPolyhedronReader : See here for details on primitive arguments
         """
-        path_to_file = Path(path_to_file) # Check that we can interpret this as a path.
-        path_to_file.resolve(strict=True) # Check that file exists, raise error otherwise.
-        return self.__CreatePrimitive(c_CSPrimitives.POLYHEDRONREADER, filename=path_to_file.name, **kw)
+        return self.__CreatePrimitive(c_CSPrimitives.POLYHEDRONREADER, filename=filename, **kw)
 
     def __CreatePrimitive(self, prim_type, **kw):
         pset = self.GetParameterSet()

--- a/python/CSXCAD/CSProperties.pyx
+++ b/python/CSXCAD/CSProperties.pyx
@@ -40,7 +40,6 @@ cimport CSXCAD.CSProperties
 cimport CSXCAD.CSPrimitives as c_CSPrimitives
 from CSXCAD.CSPrimitives import CSPrimitives
 from CSXCAD.Utilities import CheckNyDir
-from pathlib import Path
 
 def hex2color(color):
     if color.startswith('#'):


### PR DESCRIPTION
I am using [`AddPolyhedronReader`](https://docs.openems.de/python/CSXCAD/CSProperties/CSProperties.html#CSXCAD.CSProperties.CSProperties.AddPolyhedronReader) to add some geometry stored in files. I noticed that when the file does not exist, it fails silently, meaning that the simulation is run, and you know it was not there after you look at the results, hopefully. The only way of knowing about it beforehand is by seeing a red message that is print in the terminal by some function in the C++ engine. However, this goes so fast that it is very easy to miss it. 

As a Python user, I would expect that such an error would raise an exception, and that it will raise it as soon as possible, and by default, in the same way other packages like NumPy or Pandas do.

To put a concrete example (look at `substrate`):
```python
# Taken from the examples, see [here](https://docs.openems.de/python/openEMS/Tutorials/Simple_Patch_Antenna.html).

import os, tempfile
from pylab import *

from CSXCAD  import ContinuousStructure
from openEMS import openEMS
from openEMS.physical_constants import *
import logging

# General parameter setup

Sim_Path = os.path.join(tempfile.gettempdir(), 'Simp_Patch')

post_proc_only = False

# patch width (resonant length) in x-direction
patch_width  = 32 #
# patch length in y-direction
patch_length = 40

#substrate setup
substrate_epsR   = 3.38
substrate_kappa  = 1e-3 * 2*pi*2.45e9 * EPS0*substrate_epsR
substrate_thickness = 1.524
substrate_cells = 4

#setup feeding
feed_pos = -6 #feeding position in x-direction
feed_R = 50     #feed resistance

# size of the simulation box
SimBox = np.array([200, 200, 150])

# setup FDTD parameter & excitation function
f0 = 2e9 # center frequency
fc = 1e9 # 20 dB corner frequency

# FDTD setup
#    Limit the simulation to 30k timesteps
#    Define a reduced end criteria of -40dB

FDTD = openEMS(NrTS=30000, EndCriteria=1e-4)
FDTD.SetGaussExcite( f0, fc )
FDTD.SetBoundaryCond( ['MUR', 'MUR', 'MUR', 'MUR', 'MUR', 'MUR'] )

CSX = ContinuousStructure()
FDTD.SetCSX(CSX)
mesh = CSX.GetGrid()
mesh.SetDeltaUnit(1e-3)
mesh_res = C0/(f0+fc)/1e-3/20

# Generate properties, primitives and mesh-grid

#initialize the mesh with the "air-box" dimensions
mesh.AddLine('x', [-SimBox[0]/2, SimBox[0]/2])
mesh.AddLine('y', [-SimBox[1]/2, SimBox[1]/2]          )
mesh.AddLine('z', [-SimBox[2]/3, SimBox[2]*2/3]        )

# create patch
patch = CSX.AddMetal( 'patch' ) # create a perfect electric conductor (PEC)
start = [-patch_width/2, -patch_length/2, substrate_thickness]
stop  = [ patch_width/2 , patch_length/2, substrate_thickness]
patch.AddBox(priority=10, start=start, stop=stop) # add a box-primitive to the metal property 'patch'
FDTD.AddEdges2Grid(dirs='xy', properties=patch, metal_edge_res=mesh_res/2)

# create substrate
substrate = CSX.AddMaterial('substrate', epsilon=substrate_epsR, kappa=substrate_kappa)
substrate.AddPolyhedronReader('inexistent_file.stl', priority=0).ReadFile()

# add extra cells to discretize the substrate thickness
mesh.AddLine('z', linspace(0,substrate_thickness,substrate_cells+1))

# create ground (same size as substrate)
gnd = CSX.AddMetal( 'gnd' ) # create a perfect electric conductor (PEC)
start[2]=0
stop[2] =0
gnd.AddBox(start, stop, priority=10)

FDTD.AddEdges2Grid(dirs='xy', properties=gnd)

# apply the excitation & resist as a current source
start = [feed_pos, 0, 0]
stop  = [feed_pos, 0, substrate_thickness]
port = FDTD.AddLumpedPort(1, feed_R, start, stop, 'z', 1.0, priority=5, edges2grid='xy')

mesh.SmoothMeshLines('all', mesh_res, 1.4)

# Add the nf2ff recording box
nf2ff = FDTD.CreateNF2FFBox()

# Run the simulation

if 0:  # debugging only
    CSX_file = os.path.join(Sim_Path, 'simp_patch.xml')
    if not os.path.exists(Sim_Path):
        os.mkdir(Sim_Path)
    CSX.Write2XML(CSX_file)
    from CSXCAD import AppCSXCAD_BIN
    os.system(AppCSXCAD_BIN + ' "{}"'.format(CSX_file))

if not post_proc_only:
    FDTD.Run(Sim_Path, verbose=3, cleanup=True)

# Post-processing and plotting

f = np.linspace(max(1e9,f0-fc),f0+fc,401)
port.CalcPort(Sim_Path, f)
s11 = port.uf_ref/port.uf_inc
s11_dB = 20.0*np.log10(np.abs(s11))
figure()
plot(f/1e9, s11_dB, 'k-', linewidth=2, label='$S_{11}$')
grid()
legend()
ylabel('S-Parameter (dB)')
xlabel('Frequency (GHz)')

idx = np.where((s11_dB<-10) & (s11_dB==np.min(s11_dB)))[0]
if not len(idx)==1:
    print('No resonance frequency found for far-field calulation')
else:
    f_res = f[idx[0]]
    theta = np.arange(-180.0, 180.0, 2.0)
    phi   = [0., 90.]
    nf2ff_res = nf2ff.CalcNF2FF(Sim_Path, f_res, theta, phi, center=[0,0,1e-3])

    figure()
    E_norm = 20.0*np.log10(nf2ff_res.E_norm[0]/np.max(nf2ff_res.E_norm[0])) + nf2ff_res.Dmax[0]
    plot(theta, np.squeeze(E_norm[:,0]), 'k-', linewidth=2, label='xz-plane')
    plot(theta, np.squeeze(E_norm[:,1]), 'r--', linewidth=2, label='yz-plane')
    grid()
    ylabel('Directivity (dBi)')
    xlabel('Theta (deg)')
    title('Frequency: {} GHz'.format(f_res/1e9))
    legend()

Zin = port.uf_tot/port.if_tot
figure()
plot(f/1e9, np.real(Zin), 'k-', linewidth=2, label=r'$\Re\{Z_{in}\}$')
plot(f/1e9, np.imag(Zin), 'r--', linewidth=2, label=r'$\Im\{Z_{in}\}$')
grid()
legend()
ylabel('Zin (Ohm)')
xlabel('Frequency (GHz)')

show()
```

That will fail silently, just with a tiny print of some lines. From the current implementation, the expected usage would look something like:

```python
if substrate.AddPolyhedronReader('inexistent_file.stl', priority=0).ReadFile() != True:
    raise FileNotFoundError('blah')
```

which is very C-like, but absolutely not pythonic. So, in Python, I would say that is a bad design.