### PR TITLE
Fixed install instructions

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,14 +1,11 @@
 # CSXCAD python interface
 
 ## Install
-* Simple version:
-```python
-python setup.py install
-```
+If openEMS was installed into `~/opt/openEMS`, then install this package with:
 
-* Extended options, e.g. for custom install path at */opt/openEMS*:
 ```python
-python setup.py build_ext -I/opt/openEMS/include -L/opt/openEMS/lib -R/opt/openEMS/lib"
+python setup.py build_ext -I ~/opt/openEMS/include -L ~/opt/openEMS/lib -R ~/opt/openEMS/lib"
 pyhton setup.py install
 ```
-**Note:** The install command may require root on Linux, or add --user to install to ~/.local
+
+Otherwise, replace `~/opt/openEMS` with the path to the place where it was installed.

--- a/python/README.md
+++ b/python/README.md
@@ -3,9 +3,9 @@
 ## Install
 If openEMS was installed into `~/opt/openEMS`, then install this package with:
 
-```python
-python setup.py build_ext -I ~/opt/openEMS/include -L ~/opt/openEMS/lib -R ~/opt/openEMS/lib"
-pyhton setup.py install
+```bash
+python setup.py build_ext -I ~/opt/openEMS/include -L ~/opt/openEMS/lib -R ~/opt/openEMS/lib
+python setup.py install
 ```
 
 Otherwise, replace `~/opt/openEMS` with the path to the place where it was installed.


### PR DESCRIPTION
Fixed installation instructions.
1. The "easy" does not work, so I removed it.
2. The other one had typos, and was also not consistent with the recommendation from [the install instructions](https://docs.openems.de/install/clone-build-install.html#clone) where the `opt` directory is in the home, and not in `/`.
3. Removed the note about requiring sudo privileges, as it should not be needed. It is just a python package, it could (and should) even be installed inside a virtual environment.