### PR TITLE
matlab: reformat all docstrings as legal Markdown.

### DIFF
--- a/matlab/AddBox.m
+++ b/matlab/AddBox.m
@@ -3,22 +3,24 @@ function CSX = AddBox(CSX, propName, prio, start, stop, varargin)
 %
 % Add a box to CSX and assign to a property with name <propName>.
 %
-%  start:   box start coordinates
-%  stop :   box stop  coordinates
-%  prio :   primitive priority
+% - start:   box start coordinates
+% - stop :   box stop  coordinates
+% - prio :   primitive priority
 %
 % optional:
-%   Transformation: perform a transformation on a primitive by adding
-%      e.g.: 'Transform', {'Scale','1,1,2','Rotate_X',pi/4,'Translate','0,0,100'}
-%      Note: This will only affect the 3D material/metal discretisation
+% - Transformation: perform a transformation on a primitive by adding
+%   e.g.: 'Transform', {'Scale','1,1,2','Rotate_X',pi/4,'Translate','0,0,100'}
+%   Note: This will only affect the 3D material/metal discretisation
 %
-%   example:
-%       CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
-%       CSX = AddBox(CSX,'metal',10,[0 0 0],[100 100 200]); %assign box
+% example:
 %
-%   with transformation:
-%       CSX = AddBox(CSX,'metal',10,[0 0 0],[100 100 200], ...
-%                        'Transform', {Rotate_Z, pi/4});
+%     CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
+%     CSX = AddBox(CSX,'metal',10,[0 0 0],[100 100 200]); %assign box
+%
+% with transformation:
+%
+%     CSX = AddBox(CSX,'metal',10,[0 0 0],[100 100 200], ...
+%                      'Transform', {Rotate_Z, pi/4});
 %
 % See also AddCylinder, AddCylindricalShell, AddSphere, AddSphericalShell,
 % AddCurve, AddWire, AddMetal

--- a/matlab/AddConductingSheet.m
+++ b/matlab/AddConductingSheet.m
@@ -8,11 +8,12 @@ function CSX = AddConductingSheet(CSX, name, conductivity, thickness)
 % Hint:
 %   Set the thickness to 0 to fall back to a perfect metal (AddMetal)
 %
-%   example:
-%       % create the conducting material peroperty, e.g. 40um thick copper
-%       CSX = AddConductingSheet(CSX,'copper',56e6,40e-6);
-%       % assign box the 2D box --> 40um thick sheet
-%       CSX = AddBox(CSX,'copper',10,[0 -50 200],[1000 50 200]);
+% example:
+%
+%     % create the conducting material peroperty, e.g. 40um thick copper
+%     CSX = AddConductingSheet(CSX,'copper',56e6,40e-6);
+%     % assign box the 2D box --> 40um thick sheet
+%     CSX = AddBox(CSX,'copper',10,[0 -50 200],[1000 50 200]);
 %
 % See also AddMaterial, AddMetal, AddExcitation, AddBox
 %

--- a/matlab/AddCurve.m
+++ b/matlab/AddCurve.m
@@ -6,22 +6,23 @@ function CSX = AddCurve(CSX, propName, prio, points, varargin)
 % Warning: This is a 1D object, not all properties may be compatible with a
 % 1D object, e.g. a material property.
 %
-%  points:      curve coordinates array
-%  prio :       primitive priority
+% - points:      curve coordinates array
+% - prio :       primitive priority
 %
-%   example:
-%       %first point
-%       points(1,1) = 0;
-%       points(2,1) = 5;
-%       points(3,1) = 10;
-%       %second point
-%       points(1,2) = 0;
-%       points(2,2) = 10;
-%       points(3,2) = 10;
-%       %third point ...
-%       % create a thin metal wire...
-%       CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
-%       CSX = AddCurve(CSX,'metal',10, points);
+% example:
+%
+%     %first point
+%     points(1,1) = 0;
+%     points(2,1) = 5;
+%     points(3,1) = 10;
+%     %second point
+%     points(1,2) = 0;
+%     points(2,2) = 10;
+%     points(3,2) = 10;
+%     %third point ...
+%     % create a thin metal wire...
+%     CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
+%     CSX = AddCurve(CSX,'metal',10, points);
 %
 % See also AddBox, AddCylindricalShell, AddCylinder, AddSphere,
 % AddSphericalShell, AddWire, AddMetal

--- a/matlab/AddCylinder.m
+++ b/matlab/AddCylinder.m
@@ -3,14 +3,15 @@ function CSX = AddCylinder(CSX, propName, prio, start, stop, rad, varargin)
 %
 % Add a cylinder to CSX and assign to a property with name <propName>.
 %
-%  start:   cylinder axis start coordinates
-%  stop :   cylinder axis box stop  coordinates
-%  rad  :   cylinder radius
-%  prio :   primitive priority
+% - start:   cylinder axis start coordinates
+% - stop :   cylinder axis box stop  coordinates
+% - rad  :   cylinder radius
+% - prio :   primitive priority
 %
-%   example:
-%       CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
-%       CSX = AddCylinder(CSX,'metal',10,[0 0 0],[0 0 200],50);
+% example:
+%
+%     CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
+%     CSX = AddCylinder(CSX,'metal',10,[0 0 0],[0 0 200],50);
 %
 % See also AddBox, AddCylindricalShell, AddSphere, AddSphericalShell,
 % AddCurve, AddWire, AddMetal

--- a/matlab/AddCylindricalShell.m
+++ b/matlab/AddCylindricalShell.m
@@ -3,19 +3,20 @@ function CSX = AddCylindricalShell(CSX, propName, prio, start, stop, rad, shell_
 %
 % Add a cylinder shell to CSX and assign to a property with name <propName>.
 %
-%  start:       cylinder axis start coordinates
-%  stop :       cylinder axis box stop  coordinates
-%  rad  :       cylinder radius
-%  shell_width: cylinder shell width
-%  prio :       primitive priority
+% - start:       cylinder axis start coordinates
+% - stop :       cylinder axis box stop  coordinates
+% - rad  :       cylinder radius
+% - shell_width: cylinder shell width
+% - prio :       primitive priority
 %
-%  Note:
-%       the inner radius of this shell is rad-shell_width/2
-%       the outer radius of this shell is rad+shell_width/2
+% Note:
+% - the inner radius of this shell is rad-shell_width/2
+% - the outer radius of this shell is rad+shell_width/2
 %
-%   example:
-%       CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
-%       CSX = AddCylindricalShell(CSX,'metal',10,[0 0 0],[0 0 200],50,10);
+% example:
+%
+%     CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
+%     CSX = AddCylindricalShell(CSX,'metal',10,[0 0 0],[0 0 200],50,10);
 %
 % See also AddBox, AddCylinder, AddSphere, AddSphericalShell,
 % AddCurve, AddWire, AddMetal

--- a/matlab/AddDebyeMaterial.m
+++ b/matlab/AddDebyeMaterial.m
@@ -4,17 +4,19 @@ function CSX = AddDebyeMaterial(CSX, name, varargin)
 % Add a Debye type dispersive material model.
 %
 % The Debye type frequency dependent material:
-% eps_r(w) = eps_r + sum_p ( eps_r_delta,p / (1+jw*t_relex,p) ) - j*kappa/w
+%
+%     eps_r(w) = eps_r + sum_p ( eps_r_delta,p / (1+jw*t_relex,p) ) - j*kappa/w
 %
 % with
-% eps_r_delta,p: the delta electric relative permitivity
-% t_relex,p:     the electric relaxation time
+% - eps_r_delta,p: the delta electric relative permitivity
+% - t_relex,p:     the electric relaxation time
 %
 % Use SetMaterialProperty to define the material constants:
-%   'EpsilonDelta_p':      p-th eps_r_delta,p
-%   'EpsilonRelaxTime_p':  p-th t_relex,p
+% - 'EpsilonDelta_p':      p-th eps_r_delta,p
+% - 'EpsilonRelaxTime_p':  p-th t_relex,p
 %
 % example:
+%
 %     CSX = AddDebyeMaterial(CSX,'debye');
 %     CSX = SetMaterialProperty(CSX,'debye','Epsilon',5,'EpsilonDelta_1',0.1,'EpsilonRelaxTime_1',1e-9);
 %     [..]

--- a/matlab/AddDiscMaterial.m
+++ b/matlab/AddDiscMaterial.m
@@ -6,21 +6,22 @@ function CSX = AddDiscMaterial(CSX, name, varargin)
 % Use Transform option to perfom some transformation actions.
 %
 % variable arguments (key/value)
-%  'File' (mandatory): define the filename of the discrete material
-%  'Scale':            scale the discrete material
-%                      e.g. to your drawing units: 'Scale', 1/unit
-%  'Transform':        Apply a transformation, see AddBox for more infos
-%  'UseDBBackground':  set to 0, to use the properties background material
+% - 'File' (mandatory): define the filename of the discrete material
+% - 'Scale':            scale the discrete material
+%                       e.g. to your drawing units: 'Scale', 1/unit
+% - 'Transform':        Apply a transformation, see AddBox for more infos
+% - 'UseDBBackground':  set to 0, to use the properties background material
 %                      instead of the database material with index 0 (default)
 %
 % examples:
-% %add human body model
-% CSX = AddDiscMaterial(CSX, 'Ella', 'Scale', 1/unit, ...
-%   'Transform', {'Rotate_Z',pi/2,'Translate','300,300,500'}, ...
-%   'File', 'model_file_name.h5' );
-% start = [mesh.x(1)   mesh.y(1)   mesh.z(1)];
-% stop  = [mesh.x(end) mesh.y(end) mesh.z(end)];
-% CSX = AddBox(CSX,'Ella', 0 ,start,stop);
+%
+%     %add human body model
+%     CSX = AddDiscMaterial(CSX, 'Ella', 'Scale', 1/unit, ...
+%       'Transform', {'Rotate_Z',pi/2,'Translate','300,300,500'}, ...
+%       'File', 'model_file_name.h5' );
+%     start = [mesh.x(1)   mesh.y(1)   mesh.z(1)];
+%     stop  = [mesh.x(end) mesh.y(end) mesh.z(end)];
+%     CSX = AddBox(CSX,'Ella', 0 ,start,stop);
 %
 % See also AddBox, AddMetal, AddExcitation, AddProbe, AddDump 
 %

--- a/matlab/AddDump.m
+++ b/matlab/AddDump.m
@@ -4,69 +4,78 @@ function CSX = AddDump(CSX, name, varargin)
 % Add a dump property to CSX with the given name.
 % 
 % possible arguments for useage with openEMS:
-%   DumpType:   0 for E-field time-domain dump (default)
-%               1 for H-field time-domain dump
-%               2 for electric current time-domain dump
-%               3 for total current density (rot(H)) time-domain dump
-%               4 for D-field (electric flux density) time-domain dump
-%               5 for B-field (magnetic flux density) time-domain dump
+% - DumpType:
+%   - 0 for E-field time-domain dump (default)
+%   - 1 for H-field time-domain dump
+%   - 2 for electric current time-domain dump
+%   - 3 for total current density (rot(H)) time-domain dump
+%   - 4 for D-field (electric flux density) time-domain dump
+%   - 5 for B-field (magnetic flux density) time-domain dump
 %
-%              10 for E-field frequency-domain dump
-%              11 for H-field frequency-domain dump
-%              12 for electric current frequency-domain dump
-%              13 for total current density (rot(H)) frequency-domain dump
-%              14 for D-field (electric flux density) frequency-domain dump
-%              15 for B-field (magnetic flux density) frequency-domain dump
+%   - 10 for E-field frequency-domain dump
+%   - 11 for H-field frequency-domain dump
+%   - 12 for electric current frequency-domain dump
+%   - 13 for total current density (rot(H)) frequency-domain dump
+%   - 14 for D-field (electric flux density) frequency-domain dump
+%   - 15 for B-field (magnetic flux density) frequency-domain dump
 %
-%              20 local SAR frequency-domain dump
-%              21  1g averaging SAR frequency-domain dump
-%              22 10g averaging SAR frequency-domain dump
+%   - 20 local SAR frequency-domain dump
+%   - 21  1g averaging SAR frequency-domain dump
+%   - 22 10g averaging SAR frequency-domain dump
 %
-%              29 raw data needed for SAR calculations (electric field FD,
-%                 cell volume, conductivity and density)
+%   - 29 raw data needed for SAR calculations (electric field FD,
+%        cell volume, conductivity and density)
 %
-%   Frequency:  specify a frequency vector (required for dump types >=10)
+% - Frequency:  specify a frequency vector (required for dump types >=10)
 %
-%   DumpMode:   0 no-interpolation
-%               1 node-interpolation (default, see warning below)
-%               2 cell-interpolation (see warning below)
+% - DumpMode:
+%   - 0 no-interpolation
+%   - 1 node-interpolation (default, see warning below)
+%   - 2 cell-interpolation (see warning below)
 %
-%   FileType:   0 vtk-file dump      (default)
-%               1 hdf5-file dump
+% - FileType:
+%   - 0 vtk-file dump      (default)
+%   - 1 hdf5-file dump
 %
-%   SubSampling:   field domain sub-sampling, e.g. '2,2,4'
-%   OptResolution: field domain dump resolution, e.g. '10' or '10,20,5'
+% - SubSampling:   field domain sub-sampling, e.g. '2,2,4'
+% - OptResolution: field domain dump resolution, e.g. '10' or '10,20,5'
 %
-%   MultiGridLevel: Request to dump from a multigrid level (default is 0)
+% - MultiGridLevel: Request to dump from a multigrid level (default is 0)
 %                   Note: This only takes effect if the method supports and
 %                   uses multiple grids!
 %
-%   StartTime/StopTime: Define a start and/or stop time (in seconds) 
+% - StartTime/StopTime: Define a start and/or stop time (in seconds) 
 %                       for this dump to be active.
 % 
-%   Warning:
-%       FDTD Interpolation abnormalities:
-%         - no-interpolation: fields are located in the mesh by the
-%           Yee-scheme, the mesh only specifies E- or H-Yee-nodes 
-%             --> use node- or cell-interpolation or be aware of the offset
-%         - E-field dump & node-interpolation: normal electric fields on
-%           boundaries will have false amplitude due to forward/backward
-%           interpolation  in case of (strong) changes in material
-%           permittivity or on metal surfaces
-%             --> use no- or cell-interpolation
-%         - H-field dump & cell-interpolation: normal magnetic fields on
-%           boundaries will have false amplitude due to forward/backward
-%           interpolation in case of (strong) changes in material permeability
-%             --> use no- or node-interpolation
+% - Warning:
+%   - FDTD Interpolation abnormalities
+%   - no-interpolation: fields are located in the mesh by the
+%     Yee-scheme, the mesh only specifies E- or H-Yee-nodes 
+%       --> use node- or cell-interpolation or be aware of the offset
+%   - E-field dump & node-interpolation: normal electric fields on
+%     boundaries will have false amplitude due to forward/backward
+%     interpolation  in case of (strong) changes in material
+%     permittivity or on metal surfaces
+%       --> use no- or cell-interpolation
+%   - H-field dump & cell-interpolation: normal magnetic fields on
+%     boundaries will have false amplitude due to forward/backward
+%     interpolation in case of (strong) changes in material permeability
+%       --> use no- or node-interpolation
 %
-% e.g. AddDump(CSX,'Et');
-%      CSX = AddBox(CSX,'Et',10,[0 0 0],[100 100 200]); %assign box
+% e.g.
+%
+%     AddDump(CSX,'Et');
+%     CSX = AddBox(CSX,'Et',10,[0 0 0],[100 100 200]); %assign box
 % 
-% or   AddDump(CSX,'Ef',DumpType, 10, 'Frequency',[1e9 2e9]);
-%      CSX = AddBox(CSX,'Ef',10,[0 0 0],[100 100 200]); %assign box
+% or
+%
+%     AddDump(CSX,'Ef',DumpType, 10, 'Frequency',[1e9 2e9]);
+%     CSX = AddBox(CSX,'Ef',10,[0 0 0],[100 100 200]); %assign box
 % 
-% or   AddDump(CSX,'Ht','SubSampling','2,2,4','DumpType',1);
-%      CSX = AddBox(CSX,'Ht',10,[0 0 0],[100 100 200]); %assign box
+% or
+%
+%     AddDump(CSX,'Ht','SubSampling','2,2,4','DumpType',1);
+%     CSX = AddBox(CSX,'Ht',10,[0 0 0],[100 100 200]); %assign box
 % 
 % See also AddMaterial, AddExcitation, AddProbe, AddMetal, AddBox
 % 

--- a/matlab/AddExcitation.m
+++ b/matlab/AddExcitation.m
@@ -3,23 +3,24 @@ function CSX = AddExcitation(CSX, name, type, excite, varargin)
 %
 % Creates an E-field or H-field excitation.
 %
-% CSX: CSX-struct created by InitCSX
-% name: property name for the excitation
-% type: 0=E-field soft excitation  1=E-field hard excitation
-%       2=H-field soft excitation  3=H-field hard excitation
-%       10=plane wave excitation
+% - CSX: CSX-struct created by InitCSX
+% - name: property name for the excitation
+% - type: 0=E-field soft excitation  1=E-field hard excitation
+%         2=H-field soft excitation  3=H-field hard excitation
+%         10=plane wave excitation
 %
 % excite: e.g. [2 0 0] for excitation of 2 V/m in x-direction
 % 
 % additional options for openEMS:
-%   'Delay'  : setup an excitation time delay in seconds
-%   'PropDir': direction of plane wave propagation (plane wave excite only)
+% - 'Delay'  : setup an excitation time delay in seconds
+% - 'PropDir': direction of plane wave propagation (plane wave excite only)
 %
 % example:
-%   CSX = AddExcitation( CSX, 'infDipole', 1, [1 0 0] );
-%   start = [-dipole_length/2, 0, 0];
-%   stop  = [+dipole_length/2, 0, 0];
-%   CSX = AddBox( CSX, 'infDipole', 1, start, stop );
+%
+%     CSX = AddExcitation( CSX, 'infDipole', 1, [1 0 0] );
+%     start = [-dipole_length/2, 0, 0];
+%     stop  = [+dipole_length/2, 0, 0];
+%     CSX = AddBox( CSX, 'infDipole', 1, start, stop );
 %
 %
 % CSXCAD matlab interface

--- a/matlab/AddLinPoly.m
+++ b/matlab/AddLinPoly.m
@@ -1,25 +1,26 @@
 function CSX = AddLinPoly( CSX, materialname, prio, normDir, elevation, points, Length, varargin)
 % CSX = AddLinPoly( CSX, materialname, prio, normDir, elevation, points, Length, varargin)
 %
-% CSX:          CSX-object created by InitCSX()
-% materialname: created by AddMetal() or AddMaterial()
-% prio:         priority
-% normDir:      normal direction of the polygon,
-%               e.g. 'x', 'y' or 'z', or numeric 0..2
-% elevation:    position of the polygon plane
-% points:       two-dimensional coordinates
-% length:       linear extrution in normal direction, starting at elevation
+% - CSX:          CSX-object created by InitCSX()
+% - materialname: created by AddMetal() or AddMaterial()
+% - prio:         priority
+% - normDir:      normal direction of the polygon,
+%                 e.g. 'x', 'y' or 'z', or numeric 0..2
+% - elevation:    position of the polygon plane
+% - points:       two-dimensional coordinates
+% - length:       linear extrution in normal direction, starting at elevation
 %
 % Warning: Polygon has to be defined using Cartesian Coords
 %          for use with cylindrical mesh, set 'CoordSystem',0
 %
 % example:
-% p(1,1) = 0;  % x-coord point 1
-% p(2,1) = 0;  % y-coord point 1
-% p(1,2) = 10; % x-coord point 2
-% p(2,2) = 20; % y-coord point 2
-% % normal direction: z (2)
-% CSX = AddLinPoly( CSX, 'PEC', 1, 2, 254, p , 10, 'CoordSystem',0)
+%
+%     p(1,1) = 0;  % x-coord point 1
+%     p(2,1) = 0;  % y-coord point 1
+%     p(1,2) = 10; % x-coord point 2
+%     p(2,2) = 20; % y-coord point 2
+%     % normal direction: z (2)
+%     CSX = AddLinPoly( CSX, 'PEC', 1, 2, 254, p , 10, 'CoordSystem',0)
 %
 % 2011, Thorsten Liebig <thorsten.liebig@gmx.de>
 %

--- a/matlab/AddLorentzMaterial.m
+++ b/matlab/AddLorentzMaterial.m
@@ -5,46 +5,53 @@ function CSX = AddLorentzMaterial(CSX, name, varargin)
 % Note: openEMS currently only supports a drude material type.
 %
 % The drude type frequency dependent material:
-% eps_r(f) = eps_r* ( 1 - f_eps_plasma^2/(f*(f-j/t_eps_r)) )
-% mue_r(f) = mue_r* ( 1 - f_mue_plasma^2/(f*(f-j/t_mue_r)) )
+%
+%     eps_r(f) = eps_r* ( 1 - f_eps_plasma^2/(f*(f-j/t_eps_r)) )
+%     mue_r(f) = mue_r* ( 1 - f_mue_plasma^2/(f*(f-j/t_mue_r)) )
+%
 % with
-% f_eps_plasma: the respective electric angular plasma frequency
-% f_mue_plasma: the respective magnetic angular plasma frequency
-% t_eps_r:      the respective electric relaxation time
-% t_mue_r:      the respective magnetic relaxation time
+%
+% - f_eps_plasma: the respective electric angular plasma frequency
+% - f_mue_plasma: the respective magnetic angular plasma frequency
+% - t_eps_r:      the respective electric relaxation time
+% - t_mue_r:      the respective magnetic relaxation time
 %
 % Use SetMaterialProperty to define the material constants:
-%   'EpsilonPlasmaFrequency':  electric plasma frequency (f_eps_plasma)
-%   'MuePlasmaFrequency':      magnetic plasma frequency (f_mue_plasma)
-%   'EpsilonRelaxTime':        electric plasma relaxation time (losses)
-%   'MueRelaxTime':            magnetic plasma relaxation time (losses)
+% -  'EpsilonPlasmaFrequency':  electric plasma frequency (f_eps_plasma)
+% -  'MuePlasmaFrequency':      magnetic plasma frequency (f_mue_plasma)
+% -  'EpsilonRelaxTime':        electric plasma relaxation time (losses)
+% -  'MueRelaxTime':            magnetic plasma relaxation time (losses)
 %
 % Note: all properties must be positive values
 %
 % Higher order Drude type:
-%   'EpsilonPlasmaFrequency_<n>':  n-th order electric plasma frequency (f_eps_plasma)
-%   'MuePlasmaFrequency_<n>':      n-th order magnetic plasma frequency (f_mue_plasma)
-%   'EpsilonRelaxTime_<n>':        n-th order electric plasma relaxation time (losses)
-%   'MueRelaxTime_<n>':            n-th order magnetic plasma relaxation time (losses)
+% - 'EpsilonPlasmaFrequency_<n>':  n-th order electric plasma frequency (f_eps_plasma)
+% - 'MuePlasmaFrequency_<n>':      n-th order magnetic plasma frequency (f_mue_plasma)
+% - 'EpsilonRelaxTime_<n>':        n-th order electric plasma relaxation time (losses)
+% - 'MueRelaxTime_<n>':            n-th order magnetic plasma relaxation time (losses)
 %
 % The Lorentz type frequency dependent material:
-% eps_r(f) = eps_r* ( 1 - f_eps_plasma^2/(f^2-f_eps_Lor_Pole^2-jf^2*/t_eps_r)) )
-% mue_r(f) = mue_r* ( 1 - f_mue_plasma^2/(f^2-f_mue_Lor_Pole^2-jf^2*/t_mue_r)) )
+%
+%     eps_r(f) = eps_r* ( 1 - f_eps_plasma^2/(f^2-f_eps_Lor_Pole^2-jf^2*/t_eps_r)) )
+%     mue_r(f) = mue_r* ( 1 - f_mue_plasma^2/(f^2-f_mue_Lor_Pole^2-jf^2*/t_mue_r)) )
+%
 % with the additional parameter (see above)
-% f_eps_Lor_Pole: the respective electric angular lorentz pole frequency
-% f_mue_Lor_Pole: the respective magnetic angular lorentz pole frequency
+%
+% - f_eps_Lor_Pole: the respective electric angular lorentz pole frequency
+% - f_mue_Lor_Pole: the respective magnetic angular lorentz pole frequency
 %
 % Use SetMaterialProperty to define the material constants:
-%   'EpsilonLorPoleFrequency':  electric lorentz pole frequency (f_eps_Lor_Pole)
-%   'MueLorPoleFrequency':      magnetic lorentz pole frequency (f_mue_Lor_Pole)
+% - 'EpsilonLorPoleFrequency':  electric lorentz pole frequency (f_eps_Lor_Pole)
+% - 'MueLorPoleFrequency':      magnetic lorentz pole frequency (f_mue_Lor_Pole)
 %
 % Note: all properties must be positive values
 %
 % Higher order Drude type:
-%   'EpsilonLorPoleFrequency_<n>':  n-th order electric lorentz pole frequency (f_eps_plasma)
-%   'MueLorPoleFrequency_<n>':      n-th order magnetic lorentz pole frequency (f_mue_plasma)
+% - 'EpsilonLorPoleFrequency_<n>':  n-th order electric lorentz pole frequency (f_eps_plasma)
+% - 'MueLorPoleFrequency_<n>':      n-th order magnetic lorentz pole frequency (f_mue_plasma)
 %
 % example:
+%
 %     CSX = AddLorentzMaterial(CSX,'drude');
 %     CSX = SetMaterialProperty(CSX,'drude','Epsilon',5,'EpsilonPlasmaFrequency',5e9,'EpsilonRelaxTime',1e-9);
 %     CSX = SetMaterialProperty(CSX,'drude','Mue',5,'MuePlasmaFrequency',5e9,'MueRelaxTime',1e-9);

--- a/matlab/AddLumpedElement.m
+++ b/matlab/AddLumpedElement.m
@@ -6,19 +6,20 @@ function CSX = AddLumpedElement(CSX, name, direction, varargin)
 % property.
 % 
 % arguments:
-%   direction:  0,1,2 or 'x','y','z' for the orientation of the lumped element
+% - direction:  0,1,2 or 'x','y','z' for the orientation of the lumped element
 % 
 % optional arguments:
-%   'R', 'C', 'L':  definition of the lumped element properties
-%   'Caps':         0 or 1 to (de)activate lumped element caps (1=default)
+% - 'R', 'C', 'L':  definition of the lumped element properties
+% - 'Caps':         0 or 1 to (de)activate lumped element caps (1=default)
 %                   If Caps are enable, a small PEC plate is added to each
 %                   end of the lumped element to ensure contact to e.g 
 %                   a microstrip line
 %
 % examples:
-% lumped element capacitor in y-direction with 1pF
-% CSX = AddLumpedElement( CSX, 'Capacitor', 1, 'Caps', 1, 'C', 1e-12 );
-% CSX = AddBox( CSX, 'Capacitor', 0, [0 0 0], [10 10 10] );
+%
+%     %lumped element capacitor in y-direction with 1pF
+%     CSX = AddLumpedElement( CSX, 'Capacitor', 1, 'Caps', 1, 'C', 1e-12 );
+%     CSX = AddBox( CSX, 'Capacitor', 0, [0 0 0], [10 10 10] );
 %
 % See also AddMaterial, AddMetal, AddExcitation, AddProbe, AddDump, AddBox
 %

--- a/matlab/AddMaterial.m
+++ b/matlab/AddMaterial.m
@@ -6,15 +6,16 @@ function CSX = AddMaterial(CSX, name, varargin)
 % property.
 %
 % Use SetMaterialProperty to define the material constants:
-%   'Epsilon':  relative electric permitivity
-%   'Mue':      relative magnetic permeability
-%   'Kappa':    electric conductivity
-%   'Sigma':    magnetc conductivity (non-physical property)
+% - 'Epsilon':  relative electric permitivity
+% - 'Mue':      relative magnetic permeability
+% - 'Kappa':    electric conductivity
+% - 'Sigma':    magnetc conductivity (non-physical property)
 %
 % examples:
-% CSX = AddMaterial( CSX, 'RO3010' );
-% CSX = SetMaterialProperty( CSX, 'RO3010', 'Epsilon', 10.2, 'Mue', 1 );
-% CSX = AddBox( CSX, 'RO3010', 0, [0 0 0], [100 1000 1000] );
+%
+%     CSX = AddMaterial( CSX, 'RO3010' );
+%     CSX = SetMaterialProperty( CSX, 'RO3010', 'Epsilon', 10.2, 'Mue', 1 );
+%     CSX = AddBox( CSX, 'RO3010', 0, [0 0 0], [100 1000 1000] );
 %
 % See also SetMaterialProperty, SetMaterialWeight, AddMetal, AddExcitation,
 % AddProbe, AddDump, AddBox

--- a/matlab/AddMetal.m
+++ b/matlab/AddMetal.m
@@ -5,9 +5,10 @@ function CSX = AddMetal(CSX, name)
 % Remember to add at least one or more geometrical primitives to any
 % property.
 %
-%   example:
-%       CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
-%       CSX = AddBox(CSX,'metal',10,[0 0 0],[100 100 200]); %assign box
+% example:
+%
+%     CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
+%     CSX = AddBox(CSX,'metal',10,[0 0 0],[100 100 200]); %assign box
 %
 % See also AddMaterial, AddExcitation, AddProbe, AddDump, AddBox
 % 

--- a/matlab/AddPlaneWaveExcite.m
+++ b/matlab/AddPlaneWaveExcite.m
@@ -11,19 +11,20 @@ function CSX = AddPlaneWaveExcite(CSX, name, k_dir, E_dir, f0, varargin)
 % Note: Only a single Box can be applied to this property!!
 %
 % Arguments
-% CSX:   CSX-struct created by InitCSX
-% name:  property name for the excitation
-% k_dir: unit vector of wave progation direction
-% E_dir: electric field polarisation vector (must be orthogonal to k_dir)
-% f0:    frequency for numerical phase velocity compensation (optional)
+% - CSX:   CSX-struct created by InitCSX
+% - name:  property name for the excitation
+% - k_dir: unit vector of wave progation direction
+% - E_dir: electric field polarisation vector (must be orthogonal to k_dir)
+% - f0:    frequency for numerical phase velocity compensation (optional)
 % 
 % example:
-% inc_angle = 0 /180*pi; %incident angle on the x-axis
-% k_dir = [cos(inc_angle) sin(inc_angle) 0]; % plane wave direction
-% E_dir = [0 0 1]; % plane wave polarization --> E_z
-% f0 = 500e6;      % frequency for numerical phase velocity compensation
-% 
-% CSX = AddPlaneWaveExcite(CSX, 'plane_wave', k_dir, E_dir, f0);
+%
+%     inc_angle = 0 /180*pi; %incident angle on the x-axis
+%     k_dir = [cos(inc_angle) sin(inc_angle) 0]; % plane wave direction
+%     E_dir = [0 0 1]; % plane wave polarization --> E_z
+%     f0 = 500e6;      % frequency for numerical phase velocity compensation
+%     
+%     CSX = AddPlaneWaveExcite(CSX, 'plane_wave', k_dir, E_dir, f0);
 %
 % CSXCAD matlab interface
 % -----------------------

--- a/matlab/AddPolygon.m
+++ b/matlab/AddPolygon.m
@@ -1,24 +1,25 @@
 function CSX = AddPolygon( CSX, materialname, prio, normDir, elevation, points, varargin)
 % CSX = AddPolygon( CSX, materialname, prio, normDir, elevation, points, varargin)
 %
-% CSX:          CSX-object created by InitCSX()
-% materialname: created by AddMetal() or AddMaterial()
-% prio:         priority
-% normDir:      normal direction of the polygon,
-%               e.g. 'x', 'y' or 'z', or numeric 0..2
-% elevation:    position of the polygon plane
-% points:       two-dimensional coordinates
+% - CSX:          CSX-object created by InitCSX()
+% - materialname: created by AddMetal() or AddMaterial()
+% - prio:         priority
+% - normDir:      normal direction of the polygon,
+%                 e.g. 'x', 'y' or 'z', or numeric 0..2
+% - elevation:    position of the polygon plane
+% - points:       two-dimensional coordinates
 %
 % Warning: Polygon has to be defined using Cartesian Coords
 %          for use with cylindrical mesh, set 'CoordSystem',0
 %
 % example:
-% p(1,1) = 0;  % x-coord point 1
-% p(2,1) = 0;  % y-coord point 1
-% p(1,2) = 10; % x-coord point 2
-% p(2,2) = 20; % y-coord point 2
-% % normal direction: z (2)
-% CSX = AddPolygon( CSX, 'PEC', 1, 'z', 254, p, 'CoordSystem',0)
+%
+%     p(1,1) = 0;  % x-coord point 1
+%     p(2,1) = 0;  % y-coord point 1
+%     p(1,2) = 10; % x-coord point 2
+%     p(2,2) = 20; % y-coord point 2
+%     % normal direction: z (2)
+%     CSX = AddPolygon( CSX, 'PEC', 1, 'z', 254, p, 'CoordSystem',0)
 %
 %
 % (c) 2011 Thorsten Liebig <thorsten.liebig@gmx.de>

--- a/matlab/AddPolyhedron.m
+++ b/matlab/AddPolyhedron.m
@@ -3,31 +3,33 @@ function CSX = AddPolyhedron(CSX, propName, prio, vertices, faces, varargin)
 %
 % Add a polyhedron to CSX and assign to a property with name <propName>.
 %
-%  prio:       primitive priority
-%  vertices:   cell array of all vertices
-%  faces:      cell array of all faces
+% - prio:       primitive priority
+% - vertices:   cell array of all vertices
+% - faces:      cell array of all faces
 %
-%  Note: - The polyhedron must be a closed surface for 3D discretisation
-%        - All faces must contain the vertices in a right-handed order with
-%          the normal direction for each face pointing out of the solid
+% Note:
+%  - The polyhedron must be a closed surface for 3D discretisation
+%  - All faces must contain the vertices in a right-handed order with
+%   the normal direction for each face pointing out of the solid
 %
 % optional:
-%   Transformation: perform a transformation on a primitive by adding
-%      e.g.: 'Transform', {'Scale','1,1,2','Rotate_X',pi/4,'Translate','0,0,100'}
-%      Note: This will only affect the 3D material/metal discretisation
+% - Transformation: perform a transformation on a primitive by adding
+%   e.g.: 'Transform', {'Scale','1,1,2','Rotate_X',pi/4,'Translate','0,0,100'}
+%   Note: This will only affect the 3D material/metal discretisation
 %
 % example:
-%   % example tetrahedron
-%   vertices{1}=[0 0 0];
-%   vertices{2}=[1 0 0];
-%   vertices{3}=[0 1 0];
-%   vertices{4}=[0 0 1];
-%   faces{1}=[0 2 1];
-%   faces{2}=[0 1 3];
-%   faces{3}=[0 3 2];
-%   faces{4}=[1 2 3];
-%   CSX = AddMetal( CSX, 'metal' );
-%   CSX = AddPolyhedron(CSX, 'metal', 0, vertices, faces);
+%
+%     % example tetrahedron
+%     vertices{1}=[0 0 0];
+%     vertices{2}=[1 0 0];
+%     vertices{3}=[0 1 0];
+%     vertices{4}=[0 0 1];
+%     faces{1}=[0 2 1];
+%     faces{2}=[0 1 3];
+%     faces{3}=[0 3 2];
+%     faces{4}=[1 2 3];
+%     CSX = AddMetal( CSX, 'metal' );
+%     CSX = AddPolyhedron(CSX, 'metal', 0, vertices, faces);
 %
 %
 % See also AddBox, AddCylinder, AddCylindricalShell, AddSphere, AddSphericalShell,

--- a/matlab/AddProbe.m
+++ b/matlab/AddProbe.m
@@ -6,26 +6,27 @@ function CSX = AddProbe(CSX, name, type, varargin)
 %
 % name:     name of the property and probe file 
 %
-% type:     0 for voltage probing
-%           1 for current probing
-%           2 for E-field probing
-%           3 for H-field probing
-%
-%           10 for waveguide voltage mode matching
-%           11 for waveguide current mode matching
+% type:
+% - 0 for voltage probing
+% - 1 for current probing
+% - 2 for E-field probing
+% - 3 for H-field probing
+% - 10 for waveguide voltage mode matching
+% - 11 for waveguide current mode matching
 %
 % all following parameter are optional key/value parameter:
 %
-% weight:       weighting factor (default is 1)
-% frequency:    dump in the frequency domain at the given samples (in Hz)
-% ModeFunction: A mode function (used only with type 3/4)
-% NormDir:      necessary for current probing box with dimension~=2
-% StartTime/StopTime: Define a start and/or stop time (in seconds) 
+% - weight:       weighting factor (default is 1)
+% - frequency:    dump in the frequency domain at the given samples (in Hz)
+% - ModeFunction: A mode function (used only with type 3/4)
+% - NormDir:      necessary for current probing box with dimension~=2
+% - StartTime/StopTime: Define a start and/or stop time (in seconds) 
 %                     for this probe to be active.
-
+%
 % examples:
-%       CSX = AddProbe(CSX,'ut1',0); %voltate probe
-%       CSX = AddProbe(CSX,'it1',1); %current probe
+%
+%     CSX = AddProbe(CSX,'ut1',0); %voltate probe
+%     CSX = AddProbe(CSX,'it1',1); %current probe
 %
 % See also ReadUI in the openEMS matlab interface, AddDump,
 % AddExcitation, AddMaterial, AddExcitation, AddProbe, AddBox

--- a/matlab/AddRotPoly.m
+++ b/matlab/AddRotPoly.m
@@ -1,26 +1,27 @@
 function CSX = AddRotPoly( CSX, materialname, prio, normDir, points, RotAxisDir, angle, varargin)
 % function CSX = AddRotPoly( CSX, materialname, prio, normDir, points, RotAxisDir, angle, varargin)
 %
-% CSX:          CSX-object created by InitCSX()
-% materialname: created by AddMetal() or AddMaterial()
-% prio:         priority
-% normDir:      normal direction of the polygon,
-%               e.g. 'x', 'y' or 'z', or numeric 0..2
-% points:       two-dimensional coordinates
-% RotAxisDir:   direction of the rotational axis
-%               e.g. 'x', 'y' or 'z', or numeric 0..2
-% angle (optional): rotational start/stop angle, default is [0 2pi]
+% - CSX:          CSX-object created by InitCSX()
+% - materialname: created by AddMetal() or AddMaterial()
+% - prio:         priority
+% - normDir:      normal direction of the polygon,
+%                 e.g. 'x', 'y' or 'z', or numeric 0..2
+% - points:       two-dimensional coordinates
+% - RotAxisDir:   direction of the rotational axis
+%                 e.g. 'x', 'y' or 'z', or numeric 0..2
+% - angle (optional): rotational start/stop angle, default is [0 2pi]
 %
 % Warning: Polygon has to be defined using Cartesian Coords
 %          for use with cylindrical mesh, set 'CoordSystem',0
 %
 % example:
-% p(1,1) = 0;  % x-coord point 1
-% p(2,1) = 0;  % y-coord point 1
-% p(1,2) = 10; % x-coord point 2
-% p(2,2) = 20; % y-coord point 2
-% % normal direction: z
-% CSX = AddRotPoly( CSX, 'PEC', 1, 'z', p , 'y');
+%
+%     p(1,1) = 0;  % x-coord point 1
+%     p(2,1) = 0;  % y-coord point 1
+%     p(1,2) = 10; % x-coord point 2
+%     p(2,2) = 20; % y-coord point 2
+%     % normal direction: z
+%     CSX = AddRotPoly( CSX, 'PEC', 1, 'z', p , 'y');
 %
 % 2011, Thorsten Liebig <thorsten.liebig@gmx.de>
 %

--- a/matlab/AddSphere.m
+++ b/matlab/AddSphere.m
@@ -3,13 +3,14 @@ function CSX = AddSphere(CSX, propName, prio, center, rad, varargin)
 %
 % Add a sphere to CSX and assign to a property with name <propName>.
 %
-%  center:  sphere center coordinates
-%  rad  :   sphere radius
-%  prio :   primitive priority
+% - center:  sphere center coordinates
+% - rad  :   sphere radius
+% - prio :   primitive priority
 %
-%   example:
-%       CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
-%       CSX = AddSphere(CSX,'metal',10,[0 0 0],50);
+% example:
+%
+%     CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
+%     CSX = AddSphere(CSX,'metal',10,[0 0 0],50);
 %
 % See also AddBox, AddCylindricalShell, AddCylinder, AddSphericalShell,
 % AddCurve, AddWire, AddMetal

--- a/matlab/AddSphericalShell.m
+++ b/matlab/AddSphericalShell.m
@@ -3,18 +3,19 @@ function CSX = AddSphericalShell(CSX, propName, prio, center, rad, shell_width, 
 %
 % Add a sphere shell to CSX and assign to a property with name <propName>.
 %
-%  center:      sphere center coordinates
-%  rad  :       sphere radius
-%  shell_width: sphere shell width
-%  prio :       primitive priority
+% - center:      sphere center coordinates
+% - rad  :       sphere radius
+% - shell_width: sphere shell width
+% - prio :       primitive priority
 %
-%  Note:
-%       the inner radius of this shell is rad-shell_width/2
-%       the outer radius of this shell is rad+shell_width/2
+% Note:
+% - the inner radius of this shell is rad-shell_width/2
+% - the outer radius of this shell is rad+shell_width/2
 %
-%   example:
-%       CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
-%       CSX = AddSphericalShell(CSX,'metal',10,[0 0 0],50,10);
+% example:
+%
+%     CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
+%     CSX = AddSphericalShell(CSX,'metal',10,[0 0 0],50,10);
 %
 % See also AddBox, AddCylindricalShell, AddCylinder, AddSphere,
 % AddCurve, AddWire, AddMetal

--- a/matlab/AddWire.m
+++ b/matlab/AddWire.m
@@ -6,23 +6,24 @@ function CSX = AddWire(CSX, propName, prio, points, wire_rad, varargin)
 % Warning: This is a 1D object, not all properties may be compatible with a
 % 1D object, e.g. a material property.
 %
-%  points:      curve coordinates array
-%  prio :       primitive priority
-%  wire_rad:    wire radius
+% - points:      curve coordinates array
+% - prio :       primitive priority
+% - wire_rad:    wire radius
 %
-%   example:
-%       %first point
-%       points(1,1) = 0;
-%       points(2,1) = 5;
-%       points(3,1) = 10;
-%       %second point
-%       points(1,2) = 0;
-%       points(2,2) = 10;
-%       points(3,2) = 10;
-%       %third point ...
-%       % create a metal wire with finite radius...
-%       CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
-%       CSX = AddCurve(CSX,'metal',10, points, 2);
+% example:
+%
+%     %first point
+%     points(1,1) = 0;
+%     points(2,1) = 5;
+%     points(3,1) = 10;
+%     %second point
+%     points(1,2) = 0;
+%     points(2,2) = 10;
+%     points(3,2) = 10;
+%     %third point ...
+%     % create a metal wire with finite radius...
+%     CSX = AddMetal(CSX,'metal'); %create PEC with propName 'metal'
+%     CSX = AddCurve(CSX,'metal',10, points, 2);
 %
 % See also AddBox, AddCylindricalShell, AddCylinder, AddSphere,
 % AddSphericalShell, AddCurve, AddMetal

--- a/matlab/AnalyseMesh.m
+++ b/matlab/AnalyseMesh.m
@@ -4,12 +4,12 @@ function results = AnalyseMesh(lines)
 %   Analyse a given mesh line vector
 %
 % output structure:
-%   results.numLines:       number of lines
-%   results.max_res:        max. resolution found
-%   results.min_res:        min. resolution found
-%   results.max_ratio:      max. grading ratio found
-%   results.homogeneous:    true/false for homogeneous mesh
-%   results.symmetric:      true/false for symmetric mesh
+% - results.numLines:       number of lines
+% - results.max_res:        max. resolution found
+% - results.min_res:        min. resolution found
+% - results.max_ratio:      max. grading ratio found
+% - results.homogeneous:    true/false for homogeneous mesh
+% - results.symmetric:      true/false for symmetric mesh
 %
 % CSXCAD matlab interface
 % -----------------------

--- a/matlab/AutoSmoothMeshLines.m
+++ b/matlab/AutoSmoothMeshLines.m
@@ -7,24 +7,25 @@ function [lines quality] = AutoSmoothMeshLines( lines, max_res, ratio, varargin)
 %       SmoothMeshLines, SmoothMeshLines2 and RecursiveSmoothMesh
 %
 %  arguments:
-%   lines:      given fixed lines to create a smooth mesh in between
-%   max_res:    desired max. resolution
-%   ratio:      grading ratio: desired neighboring line-delta ratio
-%                   - default is 1.5
-%                   - see also 'allowed_max_ratio' argument
+%  - lines:      given fixed lines to create a smooth mesh in between
+%  - max_res:    desired max. resolution
+%  - ratio:      grading ratio: desired neighboring line-delta ratio
+%    - default is 1.5
+%    - see also 'allowed_max_ratio' argument
 %
 %  variable arguments ('keyword',value):
-%   algorithm:          define subset of tried algorihm, e.g. [1 3]
-%   symmetric:          0/1 force symmetric mesh (default is input symmetry)
-%   homogeneous:        0/1 force homogeneous mesh
-%   allowed_min_res:    allow a given min resolution only
-%   allowed_max_ratio:  allow only a given max. grading ratio
+%  - algorithm:          define subset of tried algorihm, e.g. [1 3]
+%  - symmetric:          0/1 force symmetric mesh (default is input symmetry)
+%  - homogeneous:        0/1 force homogeneous mesh
+%  - allowed_min_res:    allow a given min resolution only
+%  - allowed_max_ratio:  allow only a given max. grading ratio
 %                           (default --> ratio*1.25)
-%   debug:              0/1 off/on
+%  - debug:              0/1 off/on
 %
 % example:
-%   lines = AutoSmoothMeshLines([-100 -10 10 100], 20, 1.5, 'algorihm', ...
-%   1:3);
+%
+%     lines = AutoSmoothMeshLines([-100 -10 10 100], 20, 1.5, 'algorihm', ...
+%     1:3);
 %
 % See also InitCSX, DefineRectGrid
 %

--- a/matlab/CSXGeomPlot.m
+++ b/matlab/CSXGeomPlot.m
@@ -4,11 +4,11 @@ function CSXGeomPlot(CSX_filename, args_string)
 % Show the geometry stored in the CSX file using AppCSXCAD
 %
 % Optional AppCSXCAD arguments (args_string):
-%   '--RenderDiscMaterial', enable material rendering
+% - '--RenderDiscMaterial', enable material rendering
 %
-%  exports:
-%   '--export-polydata-vtk=<path-for-export>'
-%   '--export-STL=<path-for-export>'
+% exports:
+% - '--export-polydata-vtk=<path-for-export>'
+% - '--export-STL=<path-for-export>'
 %
 % See also InitCSX, DefineRectGrid
 %

--- a/matlab/CalcDebyeMaterial.m
+++ b/matlab/CalcDebyeMaterial.m
@@ -4,14 +4,14 @@ function eps_debye = CalcDebyeMaterial(f, eps_r, kappa, eps_Delta, t_relax)
 % Calculate the Debye type dispersive material constant
 %
 % arguments:
-%   f:      frequeny range of interest
-%   eps_r:  eps_r infinity
-%   kappa:  conductivity (losses)
-%   eps_Delta: (vector) delta of relative permitivity
-%   t_relax:  (vector) relaxation time (losses)
+% - f:      frequeny range of interest
+% - eps_r:  eps_r infinity
+% - kappa:  conductivity (losses)
+% - eps_Delta: (vector) delta of relative permitivity
+% - t_relax:  (vector) relaxation time (losses)
 %
 % return:
-%   eps_debye:    the complex relative permitivity
+% - eps_debye:    the complex relative permitivity
 %
 % See also: CalcLorentzMaterial
 %

--- a/matlab/CalcDrudeMaterial.m
+++ b/matlab/CalcDrudeMaterial.m
@@ -4,31 +4,32 @@ function eps_drude = CalcDrudeMaterial(f, eps_r, kappa, plasmaFreq, t_relax)
 % Calculate the Drude type dispersive material constant
 %
 % arguments:
-%   f:           frequeny range of interest
-%   eps_r:       eps_r infinity
-%   kappa:       conductivity (losses)
-%   plasmaFreq:  (vector) plasma frequencies
-%   t_relax:     (vector) relaxation time (losses)
+% - f:           frequeny range of interest
+% - eps_r:       eps_r infinity
+% - kappa:       conductivity (losses)
+% - plasmaFreq:  (vector) plasma frequencies
+% - t_relax:     (vector) relaxation time (losses)
 %
 % return:
-%   eps_drude: the complex relative permitivity
+% - eps_drude: the complex relative permitivity
 %
 % Example:
-% % silver (AG) at optical frequencies (Drude model) [1, p. 201]
-% f = linspace(300e12, 1100e12, 201);
-% eps_model = CalcDrudeMaterial(f, 3.942, 7.97e3, 7e15/2/pi, 0, 1/2.3e13);
 %
-% figure
-% plot(f,real(eps_model))
-% hold on;
-% grid on;
-% plot(f,imag(eps_model),'r--')
+%     % silver (AG) at optical frequencies (Drude model) [1, p. 201]
+%     f = linspace(300e12, 1100e12, 201);
+%     eps_model = CalcDrudeMaterial(f, 3.942, 7.97e3, 7e15/2/pi, 0, 1/2.3e13);
+%
+%     figure
+%     plot(f,real(eps_model))
+%     hold on;
+%     grid on;
+%     plot(f,imag(eps_model),'r--')
 %
 % See also: CalcDebyeMaterial, CalcLorentzMaterial
 %
-% [1] Rennings, Andre: "Elektromagnetische Zeitbereichssimulationen
-%     innovativer Antennen auf Basis von Metamaterialien."
-%     PhD Thesis, University of Duisburg-Essen, September 2008
+% * [1] Rennings, Andre: "Elektromagnetische Zeitbereichssimulationen
+%       innovativer Antennen auf Basis von Metamaterialien."
+%       PhD Thesis, University of Duisburg-Essen, September 2008
 %
 % CSXCAD matlab interface
 % -----------------------

--- a/matlab/CalcLorentzMaterial.m
+++ b/matlab/CalcLorentzMaterial.m
@@ -4,42 +4,43 @@ function eps_lorentz = CalcLorentzMaterial(f, eps_r, kappa, plasmaFreq, LorPoleF
 % Calculate the Lorentz type dispersive material constant
 %
 % arguments:
-%   f:           frequeny range of interest
-%   eps_r:       eps_r infinity
-%   kappa:       conductivity (losses)
-%   plasmaFreq:  (vector) plasma frequencies (Drude model)
-%   LorPoleFreq: (vector) Lorentz pole frequencies (zero for pure Drude model)
-%   t_relax:     (vector) relaxation time (losses)
+% - f:           frequeny range of interest
+% - eps_r:       eps_r infinity
+% - kappa:       conductivity (losses)
+% - plasmaFreq:  (vector) plasma frequencies (Drude model)
+% - LorPoleFreq: (vector) Lorentz pole frequencies (zero for pure Drude model)
+% - t_relax:     (vector) relaxation time (losses)
 %
 % return:
-%   eps_lorentz: the complex relative permitivity
+% - eps_lorentz: the complex relative permitivity
 %
 % Example:
-% % silver (AG) at optical frequencies (Drude model) [1, p. 201]
-% f = linspace(300e12, 1100e12, 201);
-% eps_model = CalcLorentzMaterial(f, 3.942, 7.97e3, 7e15/2/pi, 0, 1/2.3e13);
 %
-% figure
-% plot(f,real(eps_model))
-% hold on;
-% grid on;
-% plot(f,imag(eps_model),'r--')
+%     % silver (AG) at optical frequencies (Drude model) [1, p. 201]
+%     f = linspace(300e12, 1100e12, 201);
+%     eps_model = CalcLorentzMaterial(f, 3.942, 7.97e3, 7e15/2/pi, 0, 1/2.3e13);
 %
-% % silver (AG) at optical frequencies (Drude+Lorentz model) [1, p. 201]
-% f = linspace(300e12, 1100e12, 201);
-% eps_model = CalcLorentzMaterial(f, 1.138, 4.04e3, [13e15 9.61e15]/2/pi, [0 7.5e15]/2/pi,[1/2.59e13 1/3e14]);
+%     figure
+%     plot(f,real(eps_model))
+%     hold on;
+%     grid on;
+%     plot(f,imag(eps_model),'r--')
 %
-% figure
-% plot(f,real(eps_model))
-% hold on;
-% grid on;
-% plot(f,imag(eps_model),'r--')
+%     % silver (AG) at optical frequencies (Drude+Lorentz model) [1, p. 201]
+%     f = linspace(300e12, 1100e12, 201);
+%     eps_model = CalcLorentzMaterial(f, 1.138, 4.04e3, [13e15 9.61e15]/2/pi, [0 7.5e15]/2/pi,[1/2.59e13 1/3e14]);
+%
+%     figure
+%     plot(f,real(eps_model))
+%     hold on;
+%     grid on;
+%     plot(f,imag(eps_model),'r--')
 %
 % See also: CalcDebyeMaterial
 %
-% [1] Rennings, Andre: "Elektromagnetische Zeitbereichssimulationen
-%     innovativer Antennen auf Basis von Metamaterialien."
-%     PhD Thesis, University of Duisburg-Essen, September 2008
+% * [1] Rennings, Andre: "Elektromagnetische Zeitbereichssimulationen
+%       innovativer Antennen auf Basis von Metamaterialien."
+%       PhD Thesis, University of Duisburg-Essen, September 2008
 %
 % CSXCAD matlab interface
 % -----------------------

--- a/matlab/CheckMesh.m
+++ b/matlab/CheckMesh.m
@@ -4,15 +4,15 @@ function [EC pos E_type] = CheckMesh(lines, min_res, max_res, ratio, be_quiet)
 %   Check if mesh lines are valid
 %
 %   parameter:
-%       min_res: minimal allowed mesh-diff
-%       max_res: maximal allowed mesh-diff
-%       ratio:   maximal allowed mesh-diff ratio
-%       be_quiet: disable warnings
+%   - min_res: minimal allowed mesh-diff
+%   - max_res: maximal allowed mesh-diff
+%   - ratio:   maximal allowed mesh-diff ratio
+%   - be_quiet: disable warnings
 %
 %   return:
-%       EC:     error code (number of found errors)
-%       pos:    line positions with error
-%       E_type: error type
+%   - EC:     error code (number of found errors)
+%   - pos:    line positions with error
+%   - E_type: error type
 %
 % CSXCAD matlab interface
 % -----------------------

--- a/matlab/Convert_VF_DiscMaterial.m
+++ b/matlab/Convert_VF_DiscMaterial.m
@@ -10,18 +10,18 @@ function Convert_VF_DiscMaterial(raw_filesuffix, mat_db_file, out_filename, vara
 % range around the used conversion frequency.
 %
 % required arguments:
-%   raw_filesuffix:     suffix for the virtual family body model files
+% - raw_filesuffix:     suffix for the virtual family body model files
 %                       the files:
 %                       <raw_filesuffix>.txt and <raw_filesuffix>.raw
 %                       must be found!
 %                       example: '/tmp/Ella_26y_V2_1mm'
-%   mat_db_file:        tissue database file (incl. full path if necessary)
+% - mat_db_file:        tissue database file (incl. full path if necessary)
 %                       example: '/tmp/DB_h5_20120711_SEMCADv14.8.h5'
-%   out_filename:       outfile name, e.g. 'Ella_298MHz.h5'
+% - out_filename:       outfile name, e.g. 'Ella_298MHz.h5'
 %
 % variable arguments (key/value):
-%   'Frequency':        specifiy the frequency of interest (required!)
-%   'Center':           0/1 make the model centered around (0,0,0)
+% - 'Frequency':        specifiy the frequency of interest (required!)
+% - 'Center':           0/1 make the model centered around (0,0,0)
 %                       (default is off)
 %
 % Requirements:
@@ -36,10 +36,11 @@ function Convert_VF_DiscMaterial(raw_filesuffix, mat_db_file, out_filename, vara
 %       Download from: http://www.itis.ethz.ch/assets/Downloads/TissueDb/DBh5_20120711_SEMCADv14.8.zip
 %
 % example:
-% Convert_VF_DiscMaterial('/tmp/Ella_26y_V2_1mm', ...
-%                         '/tmp/DB_h5_20120711_SEMCADv14.8.h5', ...
-%                         'Ella_centered_298MHz.h5', ...
-%                         'Frequency', 2.4e9);
+%
+%     Convert_VF_DiscMaterial('/tmp/Ella_26y_V2_1mm', ...
+%                             '/tmp/DB_h5_20120711_SEMCADv14.8.h5', ...
+%                             'Ella_centered_298MHz.h5', ...
+%                             'Frequency', 2.4e9);
 %
 % (c) 2013 Thorsten Liebig
 

--- a/matlab/CreateDiscMaterial.m
+++ b/matlab/CreateDiscMaterial.m
@@ -7,23 +7,24 @@ function CreateDiscMaterial(filename, data, mat_db, mesh)
 % necessary hdf5 write functions.
 %
 % arguments:
-%   filename:   hdf5 file to create (must not exist)
-%   data:       voxel based index data, index as used in mat_db-1
-%   mat_db:     material database
-%   mesh:       used voxel mesh. Note size is size(data)+[1 1 1]
+% - filename:   hdf5 file to create (must not exist)
+% - data:       voxel based index data, index as used in mat_db-1
+% - mat_db:     material database
+% - mesh:       used voxel mesh. Note size is size(data)+[1 1 1]
 %
 % example:
-%   mat_db.epsR    = [1     3      4];    %relative permittivity
-%   mat_db.kappa   = [0     0.2    0.4];  %electric conductivity (S/m)
-%   mat_db.density = [0     1000   1010]; %material density (kg/m³)
-%   mat_db.Name    = {'Background','mat2','mat3'};
 %
-%   data = [0 1 0; 2 1 2; 0 1 0];   % 3x3x3 data
-%   mesh.x = [0    0.1 0.2 0.3];    % 4 mesh lines in x-dir (3 cells)
-%   mesh.y = [-0.1 0   0.1 0.2];    % 4 mesh lines in y-dir (3 cells)
-%   mesh.z = [0    0.4 0.8 1.2];    % 4 mesh lines in z-dir (3 cells)
+%     mat_db.epsR    = [1     3      4];    %relative permittivity
+%     mat_db.kappa   = [0     0.2    0.4];  %electric conductivity (S/m)
+%     mat_db.density = [0     1000   1010]; %material density (kg/m³)
+%     mat_db.Name    = {'Background','mat2','mat3'};
 %
-%   CreateDiscMaterial('test_mat.h5', data, mat_db, mesh);
+%     data = [0 1 0; 2 1 2; 0 1 0];   % 3x3x3 data
+%     mesh.x = [0    0.1 0.2 0.3];    % 4 mesh lines in x-dir (3 cells)
+%     mesh.y = [-0.1 0   0.1 0.2];    % 4 mesh lines in y-dir (3 cells)
+%     mesh.z = [0    0.4 0.8 1.2];    % 4 mesh lines in z-dir (3 cells)
+%
+%     CreateDiscMaterial('test_mat.h5', data, mat_db, mesh);
 %
 % See also AddDiscMaterial
 %

--- a/matlab/DefineRectGrid.m
+++ b/matlab/DefineRectGrid.m
@@ -4,6 +4,7 @@ function CSX = DefineRectGrid(CSX, deltaUnit, mesh)
 % Create a rectiliniear grid.
 % 
 % example Cartesian mesh:
+%
 %     CSX = InitCSX();
 %     mesh.x = AutoSmoothMeshLines([0 a], 10);
 %     mesh.y = AutoSmoothMeshLines([0 b], 10);
@@ -11,6 +12,7 @@ function CSX = DefineRectGrid(CSX, deltaUnit, mesh)
 %     CSX = DefineRectGrid(CSX, unit,mesh);
 % 
 % example Cylindrical mesh:
+%
 %     CSX = InitCSX('CoordSystem',1);
 %     mesh.r = AutoSmoothMeshLines([0 a], 10);
 %     mesh.a = AutoSmoothMeshLines([0 2*pi], pi/30);

--- a/matlab/DetectEdges.m
+++ b/matlab/DetectEdges.m
@@ -5,22 +5,23 @@ function mesh = DetectEdges(CSX, mesh, varargin)
 % found in the CSX structure.
 %
 % optional arguments:
-%   mesh:       add edges to an existing (predefined) mesh
+% - mesh:       add edges to an existing (predefined) mesh
 %
 % optional: 'keyword', value
-%   'Debug'         enable debug mode (default is 1)
-%   'AddPropertyType'  add a list of additional property types to detect
+% - 'Debug'         enable debug mode (default is 1)
+% - 'AddPropertyType'  add a list of additional property types to detect
 %                   e.g. 'DumpBox' or {'DumpBox','ProbeBox'}
-%   'SetPropertyType'  set the list of property types to detect (override default)
+% - 'SetPropertyType'  set the list of property types to detect (override default)
 %                   e.g. 'Metal' or {'Metal','ConductingSheet'}
-%   'ExcludeProperty'  give a list of property names to exclude from
+% - 'ExcludeProperty'  give a list of property names to exclude from
 %                      detection
-%   'SetProperty'  give a list of property names to handly exlusively for detection
+% - 'SetProperty'  give a list of property names to handly exlusively for detection
 %
 % advanced options: 'keyword', value
-%   '2D_Metal_Edge_Res' define a one-third/two-third metal edge resolution
+% - '2D_Metal_Edge_Res' define a one-third/two-third metal edge resolution
 %
 % example:
+%
 %     CSX = InitCSX();
 %     % define all properties and primitives to detect
 %     % ...

--- a/matlab/ImportPLY.m
+++ b/matlab/ImportPLY.m
@@ -2,10 +2,11 @@ function CSX = ImportPLY(CSX, propName, prio, filename, varargin)
 % function CSX = ImportPLY(CSX, propName, prio, filename, varargin)
 %
 % example:
-%   CSX = AddMetal( CSX, 'cad_model' ); % create a perfect electric conductor (PEC)
-%   CSX = ImportPLY(CSX, 'cad_model',10, 'sphere.ply','Transform',{'Scale',1/unit});
 %
-%   Note: make sure the file 'sphere.ply' is in the working directory
+%     CSX = AddMetal( CSX, 'cad_model' ); % create a perfect electric conductor (PEC)
+%     CSX = ImportPLY(CSX, 'cad_model',10, 'sphere.ply','Transform',{'Scale',1/unit});
+%
+%     % Note: make sure the file 'sphere.ply' is in the working directory
 %
 % See also AddBox, AddCylinder, AddCylindricalShell, AddSphere, AddSphericalShell,
 % AddCurve, AddWire, AddMetal, ImportSTL

--- a/matlab/ImportSTL.m
+++ b/matlab/ImportSTL.m
@@ -2,10 +2,11 @@ function CSX = ImportSTL(CSX, propName, prio, filename, varargin)
 % function CSX = ImportSTL(CSX, propName, prio, filename, varargin)
 %
 % example:
-%   CSX = AddMetal( CSX, 'cad_model' ); % create a perfect electric conductor (PEC)
-%   CSX = ImportSTL(CSX, 'cad_model',10, 'sphere.stl','Transform',{'Scale',1/unit});
 %
-%   Note: make sure the file 'sphere.stl' is in the working directory
+%     CSX = AddMetal( CSX, 'cad_model' ); % create a perfect electric conductor (PEC)
+%     CSX = ImportSTL(CSX, 'cad_model',10, 'sphere.stl','Transform',{'Scale',1/unit});
+%
+%     % Note: make sure the file 'sphere.stl' is in the working directory
 %
 % See also AddBox, AddCylinder, AddCylindricalShell, AddSphere, AddSphericalShell,
 % AddCurve, AddWire, AddMetal, ImportPLY

--- a/matlab/InitCSX.m
+++ b/matlab/InitCSX.m
@@ -4,14 +4,16 @@ function CSX = InitCSX(varargin)
 % Inititalize the CSX data-structure.
 %
 % variable arguments:
-%   'CoordSystem'       : define the default coordinate system
-%                         0 -> Cartesian
-%                         1 -> Cylindircal
-%                         2 -> Sphercial (not yet implemented)
+% - 'CoordSystem'       : define the default coordinate system
+%   - 0 -> Cartesian
+%   - 1 -> Cylindircal
+%   - 2 -> Sphercial (not yet implemented)
 % 
 % example:
+%
 %     CSX = InitCSX(); %for a default cartesian mesh
 % or
+%
 %     CSX = InitCSX('CoordSystem','1'); % for a cylindrical mesh definition
 % 
 % See also DefineRectGrid, SmoothMeshLines, SmoothMeshLines2,

--- a/matlab/RecursiveSmoothMesh.m
+++ b/matlab/RecursiveSmoothMesh.m
@@ -18,21 +18,24 @@ function resultMeshPoints = RecursiveSmoothMesh(fixedMeshPoints, max_res, ratio,
 %  At a value of 1.2, the calculation takes a very long time.
 %
 %
-% Parameter:    fixedMeshPoints:    List containing points at which a mesh
-%                                    line should appear
-%               max_res:            Maximum distance between two mesh lines
-%               ratio:              Maximum grading ratio between two
-%                                    neighbour mesh lines
+% Parameter:
+% - fixedMeshPoints:    List containing points at which a mesh
+%                       line should appear
+% - max_res:            Maximum distance between two mesh lines
+% - ratio:              Maximum grading ratio between two
+%                       neighbour mesh lines
 %
 % optional variable arguments ('key', value):
-%      CheckMesh:          Do a final mesh check (default is true)
-%      allowed_max_ratio:  allow only a given max. grading ratio
-%                           (default --> ratio*1.25)
+% - CheckMesh:          Do a final mesh check (default is true)
+% - allowed_max_ratio:  allow only a given max. grading ratio
+%                       (default --> ratio*1.25)
 %
-% Returns:      resultMeshPoints:   List containing the positions of all
-%                                     mesh lines. If a empty list is
-%                                     returned, no resolution could be
-%                                     found.
+% Returns:
+%
+% - resultMeshPoints:   List containing the positions of all
+%                       mesh lines. If a empty list is
+%                       returned, no resolution could be
+%                       found.
 %
 % CSXCAD matlab interface
 % -----------------------

--- a/matlab/SetBackgroundMaterial.m
+++ b/matlab/SetBackgroundMaterial.m
@@ -4,11 +4,12 @@ function CSX = SetBackgroundMaterial(CSX, varargin)
 % Set the background material properties
 %
 % variable arguments:
-%   'Epsilon'       : background rel. electric permittivity (default 1)
-%   'Kappa'         : background electric conductivity (default 0)
-%   'Mue'           : background rel. magnetic permeability (default 1) 
+% - 'Epsilon'       : background rel. electric permittivity (default 1)
+% - 'Kappa'         : background electric conductivity (default 0)
+% - 'Mue'           : background rel. magnetic permeability (default 1) 
 %
 % example:
+%
 %     CSX = InitCSX();
 %     CSX = SetBackgroundMaterial(CSX, 'Epsilon', 4)
 % 

--- a/matlab/SetExcitationWeight.m
+++ b/matlab/SetExcitationWeight.m
@@ -4,16 +4,17 @@ function CSX = SetExcitationWeight(CSX, name, weight)
 % Define weighting functions for x-, y- and z-direction of excitation
 %
 % The functions can use the variables:
-%   x,y,z
-%   rho for the distance to z-axis
-%   r   for the distance to origin
-%   a   for alpha (as in cylindircal and spherical coord systems)
-%   t   for theta (as in the spherical coord system
+% - x,y,z
+% - rho for the distance to z-axis
+% - r   for the distance to origin
+% - a   for alpha (as in cylindircal and spherical coord systems)
+% - t   for theta (as in the spherical coord system
 %   
 %   all these variables are not weighted with the drawing unit defined by
 %   the grid
 % 
 % example:
+%
 %     start=[0 0 0];
 %     stop=[width height 0];
 %     CSX = AddExcitation(CSX,'excite',0,[1 1 0]);

--- a/matlab/SetMaterialProperty.m
+++ b/matlab/SetMaterialProperty.m
@@ -2,22 +2,23 @@ function CSX = SetMaterialProperty(CSX, name, varargin)
 % function CSX = SetMaterialProperty(CSX, name, varargin)
 %
 % Use this function to define the material constants:
-%   'Epsilon':  relative electric permittivity: [Epsilon] = 1
-%   'Mue':      relative magnetic permeability: [Mue} = 1
-%   'Kappa':    electric conductivity: [Kappa] = S/m
-%   'Sigma':    magnetic conductivity (non-physical property): [Sigma] = Ohm/m
-%   'Density':  material mass density: [Density] = kg/m^3, e.g. water: 1000
+% - 'Epsilon':  relative electric permittivity: [Epsilon] = 1
+% - 'Mue':      relative magnetic permeability: [Mue} = 1
+% - 'Kappa':    electric conductivity: [Kappa] = S/m
+% - 'Sigma':    magnetic conductivity (non-physical property): [Sigma] = Ohm/m
+% - 'Density':  material mass density: [Density] = kg/m^3, e.g. water: 1000
 %                   necessary for SAR calculations
 %
 % examples:
-% CSX = AddMaterial( CSX, 'RO3010' );
-% CSX = SetMaterialProperty( CSX, 'RO3010', 'Epsilon', 10.2, 'Mue', 1 );
-% CSX = AddBox( CSX, 'RO3010', 0, [0 0 0], [100 1000 1000] );
 %
-% % anisotropic material
-% CSX = AddMaterial( CSX, 'sheet','Isotropy',0);
-% CSX = SetMaterialProperty(CSX, 'sheet', 'Kappa', [0 0 kappa]);
-% CSX = AddBox( CSX, 'sheet', 0, [0 0 0], [10 1000 1000] );
+%     CSX = AddMaterial( CSX, 'RO3010' );
+%     CSX = SetMaterialProperty( CSX, 'RO3010', 'Epsilon', 10.2, 'Mue', 1 );
+%     CSX = AddBox( CSX, 'RO3010', 0, [0 0 0], [100 1000 1000] );
+%
+%     % anisotropic material
+%     CSX = AddMaterial( CSX, 'sheet','Isotropy',0);
+%     CSX = SetMaterialProperty(CSX, 'sheet', 'Kappa', [0 0 kappa]);
+%     CSX = AddBox( CSX, 'sheet', 0, [0 0 0], [10 1000 1000] );
 %
 % See also AddMaterial, SetMaterialWeight
 % 

--- a/matlab/SetMaterialWeight.m
+++ b/matlab/SetMaterialWeight.m
@@ -4,16 +4,17 @@ function CSX = SetMaterialWeight(CSX, name, varargin)
 % Define the material weighting function(s)
 %
 % The functions can use the variables:
-%   x,y,z
-%   rho for the distance to z-axis
-%   r   for the distance to origin
-%   a   for alpha (as in cylindircal and spherical coord systems)
-%   t   for theta (as in the spherical coord system
+% - x,y,z
+% - rho for the distance to z-axis
+% - r   for the distance to origin
+% - a   for alpha (as in cylindircal and spherical coord systems)
+% - t   for theta (as in the spherical coord system
 %   
 %   all these variables are not weighted with the drawing unit defined by
 %   the grid
 % 
 % example:
+%
 %     %material distribution as a rect-function with 4 periods
 %     start=[-500 -100 -500];
 %     stop =[ 500  100  500];

--- a/matlab/SmoothMesh.m
+++ b/matlab/SmoothMesh.m
@@ -8,22 +8,23 @@ function [mesh] = SmoothMesh( mesh, max_res, ratio, varargin)
 %       SmoothMeshLines, SmoothMeshLines2 and RecursiveSmoothMesh
 %
 %  arguments:
-%   lines:      given fixed lines to create a smooth mesh in between
-%   max_res:    scalar or vector of desired max. allowed resolution
-%   ratio:      grading ratio: scalar or vector of desired neighboring
+%  - lines:      given fixed lines to create a smooth mesh in between
+%  - max_res:    scalar or vector of desired max. allowed resolution
+%  - ratio:      grading ratio: scalar or vector of desired neighboring
 %                   line-delta ratio (optional, default is 1.5)
 %                   - see also 'allowed_max_ratio' argument
 %
 %  variable arguments ('keyword',value):
-%   algorithm:          define subset of tried algorihm, e.g. [1 3]
-%   symmetric:          0/1 force symmetric mesh (default is input symmetry)
-%   homogeneous:        0/1 force homogeneous mesh
-%   allowed_min_res:    allow a given min resolution only
-%   allowed_max_ratio:  allow only a given max. grading ratio
+%  - algorithm:          define subset of tried algorihm, e.g. [1 3]
+%  - symmetric:          0/1 force symmetric mesh (default is input symmetry)
+%  - homogeneous:        0/1 force homogeneous mesh
+%  - allowed_min_res:    allow a given min resolution only
+%  - allowed_max_ratio:  allow only a given max. grading ratio
 %                           (default --> ratio*1.25)
-%   debug:              0/1 off/on
+%  - debug:              0/1 off/on
 %
 % example:
+%
 %     mesh.x = [-BoundBox 0 BoundBox];
 %     mesh.y = [-BoundBox 0 BoundBox];
 %     mesh.z = [0 BoundBox];

--- a/matlab/SmoothMeshLines.m
+++ b/matlab/SmoothMeshLines.m
@@ -5,20 +5,21 @@ function lines = SmoothMeshLines( lines, max_res, ratio, varargin)
 % 
 %   Warning: This function may not always produce a desired output.
 % 
-%   lines:      given fixed lines to create a smooth mesh in between
-%   max_res:    desired max. resolution
-%   ratio:      max. neighboring line-delta ratio, (optional, default is 1.3)
+% - lines:      given fixed lines to create a smooth mesh in between
+% - max_res:    desired max. resolution
+% - ratio:      max. neighboring line-delta ratio, (optional, default is 1.3)
 %
 % optional variable arguments ('key', value)
-%   recursive:          SmoothMeshLines a couple of times recursivly (default is 0)
-%   CheckMesh:          Do a final mesh check (default is true)
-%   allowed_max_ratio:  allow only a given max. grading ratio
-%                           (default --> ratio*1.25)
+% - recursive:          SmoothMeshLines a couple of times recursivly (default is 0)
+% - CheckMesh:          Do a final mesh check (default is true)
+% - allowed_max_ratio:  allow only a given max. grading ratio
+%                       (default --> ratio*1.25)
 %
 % example:
-%   % create a x-mesh with lines at 0, 50 and 200 an a desired mesh
-%   resolution of 5
-%   mesh.x = SmoothMeshLines([0 50 200],5,1.3);
+%
+%     % create a x-mesh with lines at 0, 50 and 200 an a desired mesh
+%     resolution of 5
+%     mesh.x = SmoothMeshLines([0 50 200],5,1.3);
 %
 % See also InitCSX, DefineRectGrid
 % 

--- a/matlab/SmoothMeshLines2.m
+++ b/matlab/SmoothMeshLines2.m
@@ -4,20 +4,20 @@ function lines = SmoothMeshLines2(lines, max_res, ratio, varargin)
 % Create smooth mesh lines.
 %
 % input:
-%   lines:   1xn vector of (fixed) mesh lines
-%   max_res: maximum distance between any two lines (e.g. lambda/10)
-%   ratio:   (optional) default: 1.3
+% - lines:   1xn vector of (fixed) mesh lines
+% - max_res: maximum distance between any two lines (e.g. lambda/10)
+% - ratio:   (optional) default: 1.3
 %
 % optional variable arguments ('key', value)
-%   CheckMesh:          Do a final mesh check (default is true)
-%   allowed_max_ratio:  allow only a given max. grading ratio
+% - CheckMesh:          Do a final mesh check (default is true)
+% - allowed_max_ratio:  allow only a given max. grading ratio
 %                           (default --> ratio*1.25)
 % output:
-%   lines:   1xn vector of (smoothed) mesh lines
+% - lines:   1xn vector of (smoothed) mesh lines
 %
 % example:
-%   mesh.x = [0 100 2300 2400];
-%   mesh.x = SmoothMeshLines2( mesh.x, 43 );
+% - mesh.x = [0 100 2300 2400];
+% - mesh.x = SmoothMeshLines2( mesh.x, 43 );
 %
 % todo:
 %  - if gaps cannot be completely filled because of the ratio restriction,

--- a/matlab/export_empire.m
+++ b/matlab/export_empire.m
@@ -3,11 +3,11 @@ function export_empire( CSX, FDTD, filename, options )
 %
 % Exports the geometry defined in CSX to filename as an Empire python file.
 %
-% CSX: CSX-object created by InitCSX()
-% FDTD: FDTD-object created by InitFDTD()
-% filename: export filename (e.g. '/tmp/export.py')
+% - CSX: CSX-object created by InitCSX()
+% - FDTD: FDTD-object created by InitFDTD()
+% - filename: export filename (e.g. '/tmp/export.py')
 % options (optional): struct
-%   options.ignore  : cell array with property names to ignore
+% -  options.ignore  : cell array with property names to ignore
 %
 % CSXCAD matlab interface
 % -----------------------

--- a/matlab/export_excellon.m
+++ b/matlab/export_excellon.m
@@ -5,14 +5,14 @@ function export_excellon( CSX, filename, options )
 % Only cylinders will be considered for export.
 % The xy-plane is exported.
 %
-% CSX: CSX-object created by InitCSX()
-% filename: export filename (e.g. '/tmp/export.gbr')
-% options (optional): struct
-%   .header: (string) add this to the header of the file
-%      comment line must have ';' as the very first character
-%   .exclude: (cell array) ignore these CSX-properties
-%   .include: (cell array) include only these CSX-properties
-%      if neither .exclude or .include is specified, process all properties
+% - CSX: CSX-object created by InitCSX()
+% - filename: export filename (e.g. '/tmp/export.gbr')
+% - options (optional): struct
+%   - .header: (string) add this to the header of the file
+%        comment line must have ';' as the very first character
+%   - .exclude: (cell array) ignore these CSX-properties
+%   - .include: (cell array) include only these CSX-properties
+%        if neither .exclude or .include is specified, process all properties
 %
 % See also InitCSX 
 % CSXCAD matlab interface

--- a/matlab/export_gerber.m
+++ b/matlab/export_gerber.m
@@ -4,11 +4,11 @@ function export_gerber( CSX, filename, options )
 % Exports the geometry defined in CSX to filename as a gerber RS-274X file.
 % The xy-plane is exported.
 %
-% CSX: CSX-object created by InitCSX()
-% filename: export filename (e.g. '/tmp/export.gbr')
-% options (optional): struct
-%   .header: (string) add this to the header of the file
-%   .ignore: (cell array) ignore these CSX-properties
+% - CSX: CSX-object created by InitCSX()
+% - filename: export filename (e.g. '/tmp/export.gbr')
+% - options (optional): struct
+%   - .header: (string) add this to the header of the file
+%   - .ignore: (cell array) ignore these CSX-properties
 %
 % See also InitCSX 
 % CSXCAD matlab interface

--- a/matlab/export_povray.m
+++ b/matlab/export_povray.m
@@ -6,17 +6,17 @@ function export_povray( CSX, filename, options )
 % CSX: CSX-object created by InitCSX()
 % filename: export filename (e.g. '/tmp/export.pov')
 % options (optional): struct
-%   .camera: (string) use this as the camera definition line
-%            1 camera on positive x-axis
-%            2 camera on positive y-axis
-%            3 camera on positive z-axis
-%   .light:  (string) use this as the light definition line
-%            1 point light at camera position
-%   .header: (string) add this to the header of the file
-%   .ignore: (cell array) ignore these CSX-properties
-%   .obj_modifier: struct
-%      .<propname>: (string) povray object modifier for corresponding primitives
-%                   example: options.obj_modifier.copper = 'pigment { color rgbt <0.8,0.5,0,0> }';
+% - .camera: (string) use this as the camera definition line
+%   - 1 camera on positive x-axis
+%   - 2 camera on positive y-axis
+%   - 3 camera on positive z-axis
+% - .light:  (string) use this as the light definition line
+%   - 1 point light at camera position
+% - .header: (string) add this to the header of the file
+% - .ignore: (cell array) ignore these CSX-properties
+% - .obj_modifier: struct
+%    -    .<propname>: (string) povray object modifier for corresponding primitives
+%                      example: options.obj_modifier.copper = 'pigment { color rgbt <0.8,0.5,0,0> }';
 %
 % See also InitCSX 
 % CSXCAD matlab interface

--- a/matlab/isOctave.m
+++ b/matlab/isOctave.m
@@ -4,23 +4,25 @@ function [isOct,ver] = isOctave()
 % Function to test if matlab or octave is used.
 %
 % Output:
-%  isOct: bool; true, if interpreter is Octave
-%  version: struct
-%    .major:   number; major version
-%    .minor:   number; minor version
-%    .release: number; release version
+% - isOct: bool; true, if interpreter is Octave
+% - version: struct
+%    - .major:   number; major version
+%    - .minor:   number; minor version
+%    - .release: number; release version
 %
 % example (Octave 3.6.1):
-%   isOct = true
-%   version.major = 3
-%   version.minor = 6
-%   version.release = 1
+%
+%     isOct = true
+%     version.major = 3
+%     version.minor = 6
+%     version.release = 1
 %
 % example (Matlab 7.8.0.347 (R2009a)):
-%   isOct = false
-%   version.major = 7
-%   version.minor = 8
-%   version.release = 0
+%
+%     isOct = false
+%     version.major = 7
+%     version.minor = 8
+%     version.release = 0
 %
 % openEMS matlab/octave interface
 % -----------------------

--- a/matlab/searchBinary.m
+++ b/matlab/searchBinary.m
@@ -5,15 +5,17 @@ function [binary_location] = searchBinary(name, searchpath, err_fail)
 % in searchpath, look in environment search path.
 %
 % parameter:
-%   name:         name of the binary to search
-%   searchpath:   (list of) search paths
-%   err_fail:     0/1, throw an error if binary is not found (default is 1)
+%
+% - name:         name of the binary to search
+% - searchpath:   (list of) search paths
+% - err_fail:     0/1, throw an error if binary is not found (default is 1)
 %
 % Output:
-%  binary_location:
-%     if found in searchpath:                full path of binary
-%     if found in environment search path:   name of binary
-%     if not found:                          empty string
+%
+% - binary_location:
+%   - if found in searchpath:                full path of binary
+%   - if found in environment search path:   name of binary
+%   - if not found:                          empty string
 %
 %
 % openEMS matlab/octave interface


### PR DESCRIPTION
This commit reformats all docstrings in the Matlab/Octave code as legal Markdown text, which can be used for automatic generation of online documentation, while still being human-readable as plaintext.

This Pull Request should be merged together with https://github.com/thliebig/openEMS-Project/pull/311 for consistency. 