### PR TITLE
CI: Test Windows / Visual Studio 2022, and add automatic dependent repo resolution logic.

### DIFF
--- a/.github/scripts/resolve_dependent_repos.py
+++ b/.github/scripts/resolve_dependent_repos.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Yifeng Li <tomli@tomli.me>
+#
+# Permission to use, copy, modify, and/or distribute this software for
+# any purpose with or without fee is hereby granted.
+#
+# THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL
+# WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE
+# FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+# AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+# OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+#
+# To test it locally, you can create a shell script:
+#
+# #!/bin/bash
+# export GITHUB_API_URL="https://api.github.com"
+# export GITHUB_REPOSITORY_OWNER="thliebig"
+# export GITHUB_EVENT_NAME="pull_request"
+# export GITHUB_OUTPUT="/dev/null"
+# export GITHUB_FORK_OWNER="find the username who has an open pull request"
+# export GITHUB_HEAD_REF="the source branch of the same pull request"
+# export GITHUB_TOKEN="login is optional, but can bypass low API rate limit"
+#
+# Note that all variables but GITHUB_TOKEN and GITHUB_FORK_OWNER are default
+# variables on GitHub Actions, while GITHUB_TOKEN and GITHUB_FORK_OWNER is are
+# non-standard variables set manually in the ".yml" file.
+#
+# or --project openEMS, --project QCSXCAD, --project AppCSXCAD
+# python3 resolve_dependent_repos.py --project CSXCAD
+
+import argparse
+import os
+from time import sleep
+
+import json
+import urllib.request
+
+
+PROJECT_FOUNDER = "thliebig"
+
+
+def print_log(loglevel, string, title=None):
+    if loglevel not in ["debug", "notice", "warning", "error"]:
+        raise ValueError("Unsupported GitHub Actions loglevel: %s" % loglevel)
+
+    parameters = ""
+    if title:
+        parameters = " title=%s" % title
+
+    print("::%s%s::%s" % (loglevel, parameters, string))
+
+
+def getenv(var):
+    value = os.getenv(var)
+    if not value:
+        errormsg = "Unable to determine GitHub Actions variable $%s!" % var
+        print_log("error", errormsg)
+        raise ValueError(errormsg)
+    else:
+        return value
+
+
+def get_default_repo_dependency(project):
+    REPO = {
+        "fparser": {
+            "owner": PROJECT_FOUNDER,
+            "name": "fparser",
+            "branch": "master",
+        },
+        "CSXCAD": {
+            "owner": PROJECT_FOUNDER,
+            "name": "CSXCAD",
+            "branch": "master"
+        },
+        "openEMS": {
+            "owner": PROJECT_FOUNDER,
+            "name": "openEMS",
+            "branch": "master"
+        },
+        "QCSXCAD": {
+            "owner": PROJECT_FOUNDER,
+            "name": "QCSXCAD",
+            "branch": "master"
+        },
+        "AppCSXCAD": {
+            "owner": PROJECT_FOUNDER,
+            "name": "AppCSXCAD",
+            "branch": "master"
+        },
+    }
+
+    # We can check all repos, but it wastes GitHub API calls.
+    # Especially for local testing without logging it, the quota
+    # is only 60 calls/hr. You can burn it out just after a few
+    # try. It also spams useless NOTICE messages per repo to the
+    # GitHub Actions Summary.
+    #
+    # So we only check repos actually used by "project".
+    PER_PROJECT_DEPENDENCY = {
+        "CSXCAD": [REPO["fparser"]],
+        "openEMS": [REPO["fparser"], REPO["CSXCAD"]],
+        "QCSXCAD": [REPO["fparser"], REPO["CSXCAD"]],
+        "AppCSXCAD": [REPO["fparser"], REPO["CSXCAD"], REPO["QCSXCAD"]],
+    }
+    return PER_PROJECT_DEPENDENCY[project]
+
+
+def determine_repo_dependency(project):
+    github_event_name = getenv("GITHUB_EVENT_NAME")
+    if github_event_name not in ["pull_request", "push"]:
+        print_log("error", "Unable to determine $GITHUB_EVENT_NAME!")
+        return get_default_repo_dependency(project)
+
+    if github_event_name == "pull_request":
+        src_branch = getenv("GITHUB_HEAD_REF")
+    elif github_event_name == "push":
+        src_branch = getenv("GITHUB_REF_NAME")
+    else:
+        assert False
+
+    repo_dependency = get_default_repo_dependency(project)
+
+    # If this project is a fork, we need to check whether the
+    # user or organization has also forked other repos. If they
+    # did, rewrite the project owner's name to the fork owner's
+    # name. This allows the fork itself to become a new "upstream"
+    # with correct CI/CD, since forks can also accept commits
+    # and Pull Requests.
+    owner = getenv("GITHUB_REPOSITORY_OWNER")
+    if owner != PROJECT_FOUNDER:
+        for repo in repo_dependency:
+            if reponame_exists(owner, repo["name"]):
+                repo["owner"] = owner
+
+    # Furthermore, if the dependency repo has a branch with the
+    # same name as the current repo branch, use that branch instead.
+    # This allowing testing multi-repo features.
+    for repo in repo_dependency:
+        if reponame_has_branch(owner, repo["name"], src_branch):
+            repo["branch"] = src_branch
+
+            # only warn dependencies, not current repo
+            current_repo = repo["name"] == getenv("GITHUB_REPOSITORY").split("/")[1]
+
+            if not current_repo:
+                print_log(
+                    "warning",
+                    'repo %s/%s branch %s is used instead of the default branch.' %
+                    (repo["owner"], repo["name"], src_branch),
+                    title='%s/%s: different branch "%s" used' %
+                    (repo["owner"], repo["name"], src_branch)
+                )
+
+    # If the event is a pull request...
+    if github_event_name == "pull_request":
+        contributor = getenv("GITHUB_FORK_OWNER")
+
+        # check whether the contributor has forked other dependent repos.
+        for repo in repo_dependency:
+            # If they didn't, use the upstream dependency.
+            if not reponame_exists(contributor, repo["name"]):
+                continue
+
+            # If they did, check whether they've submitted an open pull
+            # request against the upstream, and the source branch uses
+            # the same name
+            pr = (
+                pr_by_user_with_branch(
+                    repo["owner"], repo["name"], contributor, src_branch
+                )
+            )
+            if not pr:
+                continue
+
+            # If they also did, use that Pull Request's merge commit as
+            # the dependency repo.
+            repo["branch"] = pr["merge_commit_sha"]
+            repo["pr_url"] = pr["html_url"]
+            print_log(
+                "warning",
+                '%s/%s: %s must be merged first before merging this commit (%s)' %
+                (repo["owner"], repo["name"], pr["html_url"], pr["title"]),
+                title="Must-Merge Pull Request: %s" % pr["html_url"]
+            )
+
+    return repo_dependency
+
+
+def url_open(url, expect_code=None):
+    DEFAULT_HEADERS = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    RETRIES = 3
+    error = None
+
+    headers = DEFAULT_HEADERS.copy()
+    try:
+        token = getenv("GITHUB_TOKEN")
+        headers["Authorization"] = "Bearer %s" % token
+    except ValueError:
+        # for local testing only
+        print_log(
+            "warning",
+            "$GITHUB_TOKEN not found! API requests are rate-limited!"
+        )
+
+    request = urllib.request.Request(url, headers=headers)
+
+    for i in range(RETRIES):
+        try:
+            response = urllib.request.urlopen(request)
+            return response, response.getcode()
+        except urllib.error.HTTPError as e:
+            if e.code == expect_code:
+                return None, e.code
+            else:
+                error = e
+        except urllib.error.URLError as e:
+            error = e
+        sleep(1)
+
+    raise error
+
+
+def url_check_existence(url):
+    response, code = url_open(url, expect_code=404)
+    if code == 404:
+        return False
+    elif code == 200:
+        return True
+    else:
+        raise RuntimeError("Unexpected HTTP status code: %d" % code)
+
+
+def reponame_exists(owner, repo):
+    API = getenv("GITHUB_API_URL")
+    url = "%s/repos/%s/%s" % (API, owner, repo)
+    return url_check_existence(url)
+
+
+def reponame_has_branch(owner, repo, branch):
+    API = getenv("GITHUB_API_URL")
+    url = "%s/repos/%s/%s/branches/%s" % (API, owner, repo, branch)
+    return url_check_existence(url)
+
+
+def pr_by_user_with_branch(owner, repo, user, branch):
+    API = getenv("GITHUB_API_URL")
+    url = "%s/repos/%s/%s/pulls?head=%s:%s" % (API, owner, repo, user, branch)
+    raw_response, code = url_open(url)
+    pr = json.loads(raw_response.read().decode("UTF-8"))
+
+    if pr:
+        return pr[0]
+    else:
+        return None
+
+
+def output_repo_dependency(repo_dependency):
+    for repo in repo_dependency:
+        repo_value = "%s/%s" % (repo["owner"], repo["name"])
+        branch_value = repo["branch"]
+        if "pr_url" in repo:
+            pr_value = repo["pr_url"]
+        else:
+            pr_value = "None"
+
+        print_log(
+            "notice", "%s, pr: %s, branch: %s" % (repo_value, pr_value, branch_value),
+            title="%s repo" % repo["name"]
+        )
+
+        with open(getenv("GITHUB_OUTPUT"), "a") as output:
+            output.write("%s_repo=%s\n" % (repo["name"], repo_value))
+            output.write("%s_branch=%s\n" % (repo["name"], branch_value))
+            output.write("%s_pr_url=%s\n" % (repo["name"], pr_value))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Resolve dependent repos')
+    parser.add_argument("--project", type=str, required=True)
+    args = parser.parse_args()
+
+    repo_dependency = determine_repo_dependency(args.project)
+    output_repo_dependency(repo_dependency)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -779,3 +779,137 @@ jobs:
             echo "Unittest CSXCAD Python module execution in venv..."
             cd $GITHUB_WORKSPACE/CSXCAD/python/tests
             python3 -m unittest
+
+  Windows:
+    runs-on: windows-latest
+    needs: Dependencies
+
+    strategy:
+      # Use "false" means a single failed build won't terminate other combinations
+      # in the matrix. This wastes CPU time, but is an important debugging tool to
+      # prevent a single broken platform from stopping the whole matrix.
+      fail-fast: false
+
+      matrix:
+        toolchain:
+          # name: toonchain name (only a name for humans to read).
+          # CC, CXX: C/C++ compiler, environment variables
+          - name: "MSVC"
+            CC: "cl"
+            CXX: "cl"
+
+          - name: "clang-cl"
+            CC: "clang-cl"
+            CXX: "clang-cl"
+
+    env:
+      VS_ROOT_DIR: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/"
+      CC: "${{ matrix.toolchain.CC }}"
+      CXX: "${{ matrix.toolchain.CXX }}"
+      CFLAGS: "/D_WIN32_WINNT=0x0601"
+      CXXFLAGS: "/D_WIN32_WINNT=0x0601"
+
+      VCPKG_CACHE_PATH: "${{ github.workspace }}/vcpkg-cache/"
+      VCPKG_BINARY_CACHE_PATH: "${{ github.workspace }}/vcpkg-cache/binary"
+      VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg-cache/binary,readwrite"
+      VCPKG_ASSET_CACHE_PATH: "${{ github.workspace }}/vcpkg-cache/asset"
+      X_VCPKG_ASSET_SOURCES: "x-azurl,file://${{ github.workspace }}/vcpkg-cache/asset,readwrite"
+
+    # allow this job to create and modify vcpkg packages for binary cache
+    permissions:
+      packages: write
+
+    name: "Windows (${{ matrix.toolchain.name }}, latest)"
+
+    steps:
+      - name: Show checkout sources
+        run: |
+          echo "$env:FPARSER_CHECKOUT_TITLE"
+        env:
+          # convert template variables to shell variables to avoid arbitrary code injection
+          FPARSER_CHECKOUT_TITLE: ${{ needs.Dependencies.outputs.fparser_checkout_title }}
+
+      # When checking out repos, I recommend running actions/checkout
+      # as soon as possible before anything else, and in the reverse
+      # order, from the project repo to its dependencies. This reduces
+      # race conditions due to force pushes (they are harmless but
+      # annoying).
+      - name: Checkout CSXCAD.git
+        uses: actions/checkout@v4
+        with:
+          path: CSXCAD
+          # checkout must be deep, not shallow.
+          # We need tags for "git describe", otherwise build fails.
+          fetch-depth: 0
+
+      - name: ${{ needs.Dependencies.outputs.fparser_checkout_title }}
+        uses: actions/checkout@v4
+        with:
+          repository: "${{ needs.Dependencies.outputs.fparser_repo }}"
+          ref: "${{ needs.Dependencies.outputs.fparser_branch }}"
+          path: fparser
+          # checkout must be deep, not shallow.
+          # We need tags for "git describe", otherwise build fails.
+          fetch-depth: 0
+
+      # It doesn't really work, because MSVC itself doesn't support long path.
+      # But for future-proofing (it does work for clang).
+      - name: Enable long paths
+        run: |
+          New-ItemProperty -Path "HKLM:/SYSTEM/CurrentControlSet/Control/FileSystem" `
+                           -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+
+      - name: Create vcpkg cache directories
+        run: |
+          mkdir -p "$env:VCPKG_CACHE_PATH"
+          mkdir -p "$env:VCPKG_BINARY_CACHE_PATH"
+          mkdir -p "$env:VCPKG_ASSET_CACHE_PATH"
+
+      - name: Restore vcpkg cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ env.VCPKG_CACHE_PATH }}
+          # almost always nonexistent
+          key: "Windows - ${{ matrix.toolchain.name }} - ${{ github.sha }}"
+          # use GitHub's fallback feature to pick the latest cache with this prefix
+          restore-keys: |
+            Windows - ${{ matrix.toolchain.name }}
+
+      - name: Build and install fparser
+        run: |
+          & "$env:VS_ROOT_DIR/Common7/Tools/Launch-VsDevShell.ps1" -Arch amd64 -HostArch amd64
+
+          cd "$env:GITHUB_WORKSPACE/fparser"
+          mkdir build && cd build
+          cmake ../ -GNinja -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON `
+                    -DCMAKE_BUILD_TYPE=Release `
+                    -DCMAKE_INSTALL_PREFIX="$HOME/opt"
+
+          cmake --build ./ --parallel
+          cmake --install ./ --parallel 8
+
+      - name: Build and install CSXCAD
+        run: |
+          & "$env:VS_ROOT_DIR/Common7/Tools/Launch-VsDevShell.ps1" -Arch amd64 -HostArch amd64
+
+          cd "$env:GITHUB_WORKSPACE/CSXCAD"
+          mkdir build && cd build
+          cmake ../ -GNinja `
+                    -DCMAKE_BUILD_TYPE=Release `
+                    -DCMAKE_INSTALL_PREFIX="$HOME/opt" `
+                    -DFPARSER_ROOT_DIR="$HOME/opt" `
+                    -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
+                    -DVCPKG_HOST_TRIPLET="x64-windows-release" `
+                    -DVCPKG_TARGET_TRIPLET="x64-windows-release"
+
+          cmake --build ./ --parallel
+          cmake --install ./ --parallel 8
+
+      - name: Save vcpkg cache
+        if: always()  # save even after a build failure.
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ env.VCPKG_CACHE_PATH }}
+          # GitHub cache is immutable and can't be overwritten
+          # save a new cache key every time
+          key: Windows - ${{ matrix.toolchain.name }} - ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,72 @@ on:
         - '**'
 
 jobs:
+  Dependencies:
+    runs-on: ubuntu-latest
+    name: "Resolve repo dependencies"
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Resolve repo dependencies
+        id: resolve-dependencies
+        # writes to $GITHUB_OUTPUT file
+        run: |
+          python3 $GITHUB_WORKSPACE/.github/scripts/resolve_dependent_repos.py \
+                  --project CSXCAD
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_FORK_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+
+      # format a human-friendly string in the following format:
+      #
+      # * Checkout XXXX.git
+      # (keep the "master" branch case boring to avoid information overload)
+      #
+      # OR:
+      #
+      # * Checkout XXXX.git | PR: https://example.com/XXXX
+      #
+      # OR:
+      #
+      # * Checkout XXXX.git | branch: feature | http://example.com/XXXX
+      - name: Format title strings
+        id: format-title
+        shell: python
+        run: |
+          import os
+
+          def format_title_string(var, repo, pr_url, branch):
+            title = "Checkout %s.git" % repo
+            if pr_url != "None":
+              title += " | PR: %s" % pr_url
+            elif branch != "master":
+              title += " | branch: %s | %s/%s/tree/%s" % (
+                branch, ${{ toJSON(github.server_url) }}, repo, branch
+              )
+            with open(os.getenv("GITHUB_OUTPUT"), "a") as output:
+              output.write("%s=%s\n" % (var, title))
+
+          format_title_string(
+            "fparser_checkout_title",
+            # escape special characters (single and double quotes) in string
+            # using JSON representation
+            ${{ toJSON(steps.resolve-dependencies.outputs.fparser_repo) }},
+            ${{ toJSON(steps.resolve-dependencies.outputs.fparser_pr_url) }},
+            ${{ toJSON(steps.resolve-dependencies.outputs.fparser_branch) }}
+          )
+
+    # map a step output to a job output
+    outputs:
+      fparser_repo: ${{ steps.resolve-dependencies.outputs.fparser_repo }}
+      fparser_branch: ${{ steps.resolve-dependencies.outputs.fparser_branch }}
+      fparser_checkout_title: ${{ steps.format-title.outputs.fparser_checkout_title }}
+
   Linux:
     runs-on: ubuntu-latest
+    needs: Dependencies
+
     defaults:
       run:
         shell: bash
@@ -111,6 +175,92 @@ jobs:
         shell: sh
         run: (ls /.dockerenv && echo Found dockerenv) || exit 1
 
+      - name: Show checkout sources
+        # bash is not installed on Alpine at this point
+        shell: sh
+        run: |
+          echo "$FPARSER_CHECKOUT_TITLE"
+        env:
+          # convert template variables to shell variables to avoid arbitrary code injection
+          FPARSER_CHECKOUT_TITLE: ${{ needs.Dependencies.outputs.fparser_checkout_title }}
+
+      # When checking out repos, I recommend running actions/checkout
+      # as soon as possible before anything else, and in the reverse
+      # order, from the project repo to its dependencies. This reduces
+      # race conditions due to force pushes (they are harmless but
+      # annoying).
+      - if: ${{ ! matrix.os.ancient }}
+        name: Checkout CSXCAD.git
+        uses: actions/checkout@v4
+        with:
+          path: CSXCAD
+          # checkout must be deep, not shallow.
+          # We need tags for "git describe", otherwise build fails.
+          fetch-depth: 0
+
+      - if: ${{ ! matrix.os.ancient }}
+        name: ${{ needs.Dependencies.outputs.fparser_checkout_title }}
+        uses: actions/checkout@v4
+        with:
+          repository: "${{ needs.Dependencies.outputs.fparser_repo }}"
+          ref: "${{ needs.Dependencies.outputs.fparser_branch }}"
+          path: fparser
+
+      - if: ${{ matrix.os.ancient }}
+        name: (legacy) Work around known problems
+        run: |
+          if [ -f /etc/centos-release ]; then
+            # IPv6 on GitHub Actions is broken, causing random network failures
+            # if a CDN rosolves to IPv6.
+            echo "ip_resolve=4" >> /etc/yum.conf
+
+            # CentOS repos are EOL and desupported
+            sed -i 's|^mirrorlist|#mirrorlist|g; s|^#baseurl|baseurl|g; s|mirror.centos.org|vault.centos.org|g' \
+                /etc/yum.repos.d/CentOS-Base.repo
+
+            yum install -y centos-release-scl || true
+            sed -i 's|^mirrorlist|#mirrorlist|g; s|^#baseurl|baseurl|g;
+                    s|^# baseurl|baseurl|g; s|mirror.centos.org|vault.centos.org|g' \
+                /etc/yum.repos.d/CentOS-SCLo-scl.repo \
+                /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+          fi
+
+      - if: ${{ matrix.os.ancient }}
+        name: (legacy) Install git
+        run: |
+          if [ -f /etc/centos-release ]; then
+            yum install -y git
+          elif grep -q "ID=ubuntu" /etc/os-release && \
+            grep -q 'VERSION_ID="14.04"' /etc/os-release; then
+              apt-get install -y git
+          fi
+
+      - if: ${{ matrix.os.ancient }}
+        name: (legacy) Checkout CSXCAD.git
+        run: |
+          git clone "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" CSXCAD
+          cd "$GITHUB_WORKSPACE/CSXCAD"
+
+          git fetch --force "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --force "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" "+refs/pull/*/merge:refs/remotes/origin/pr/*"
+          git checkout "$GITHUB_SHA"
+
+      - if: ${{ matrix.os.ancient }}
+        name: (legacy) ${{ needs.Dependencies.outputs.fparser_checkout_title }}
+        run: |
+          echo "Clone $REPO.git (branch $BRANCH)"
+          git clone "$GITHUB_SERVER_URL/$REPO.git"
+          cd "$GITHUB_WORKSPACE/$CHECKOUT_PATH"
+
+          git fetch --force "$GITHUB_SERVER_URL/$REPO.git" "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --force "$GITHUB_SERVER_URL/$REPO.git" "+refs/pull/*/merge:refs/remotes/origin/pr/*"
+          git checkout "$BRANCH"
+        env:
+          # convert template variables to shell variables to avoid arbitrary code injection
+          REPO: ${{ needs.Dependencies.outputs.fparser_repo }}
+          BRANCH: ${{ needs.Dependencies.outputs.fparser_branch }}
+          CHECKOUT_PATH: fparser
+
       - name: Install dependencies
         shell: sh
         run: |
@@ -195,22 +345,7 @@ jobs:
             # only for CI/CD test builds without networks.
             apk add iproute2
           elif [ -f /etc/centos-release ]; then
-            # IPv6 on GitHub Actions is broken, causing random network failures
-            # if a CDN rosolves to IPv6.
-            echo "ip_resolve=4" >> /etc/yum.conf
-
-            # CentOS repos are EOL and desupported
-            sed -i 's|^mirrorlist|#mirrorlist|g; s|^#baseurl|baseurl|g; s|mirror.centos.org|vault.centos.org|g' \
-                /etc/yum.repos.d/CentOS-Base.repo
-
-            yum install -y centos-release-scl || true
-            sed -i 's|^mirrorlist|#mirrorlist|g; s|^#baseurl|baseurl|g;
-                    s|^# baseurl|baseurl|g; s|mirror.centos.org|vault.centos.org|g' \
-                /etc/yum.repos.d/CentOS-SCLo-scl.repo \
-                /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-            cat /etc/yum.repos.d/CentOS-SCLo-scl.repo
-            cat /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
-
+            # "(legacy) Work around known problems" must run before this step
             yum install -y epel-release
             yum install -y git
             yum install -y gcc gcc-c++ gmp-devel mpfr-devel \
@@ -254,38 +389,6 @@ jobs:
             echo "Unknown system!"
             exit 1
           fi
-
-      - if: ${{ ! matrix.os.ancient }}
-        name: Checkout CSXCAD.git
-        uses: actions/checkout@v4
-        with:
-          repository: "${{ github.repository_owner }}/CSXCAD"
-          path: CSXCAD
-          # checkout must be deep, not shallow.
-          # We need tags for "git describe", otherwise build fails.
-          fetch-depth: 0
-
-      - if: ${{ ! matrix.os.ancient }}
-        name: Checkout fparser.git
-        uses: actions/checkout@v4
-        with:
-          repository: "${{ github.repository_owner }}/fparser"
-          path: fparser
-
-      - if: ${{ matrix.os.ancient }}
-        name: Checkout CSXCAD.git (legacy system only)
-        run: |
-          echo "Clone $GITHUB_SHA from $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
-          git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git CSXCAD
-          cd $GITHUB_WORKSPACE/CSXCAD
-
-          git fetch --force $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git "+refs/heads/*:refs/remotes/origin/*"
-          git fetch --force $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git "+refs/pull/*/merge:refs/remotes/origin/pr/*"
-          git checkout $GITHUB_SHA
-
-      - if: ${{ matrix.os.ancient }}
-        name: Checkout fparser.git (legacy system only)
-        run: git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY_OWNER/fparser.git
 
       - name: Build and install fparser
         run: |
@@ -395,7 +498,36 @@ jobs:
     name: "macOS (ARM, latest)"
 
     runs-on: macos-latest
+    needs: Dependencies
+
     steps:
+      - name: Show checkout sources
+        run: |
+          echo "$FPARSER_CHECKOUT_TITLE"
+        env:
+          # convert template variables to shell variables to avoid arbitrary code injection
+          FPARSER_CHECKOUT_TITLE: ${{ needs.Dependencies.outputs.fparser_checkout_title }}
+
+      # When checking out repos, I recommend running actions/checkout
+      # as soon as possible before anything else, and in the reverse
+      # order, from the project repo to its dependencies. This reduces
+      # race conditions due to force pushes (they are harmless but
+      # annoying).
+      - name: Checkout CSXCAD.git
+        uses: actions/checkout@v4
+        with:
+          path: CSXCAD
+          # checkout must be deep, not shallow.
+          # We need tags for "git describe", otherwise build fails.
+          fetch-depth: 0
+
+      - name: ${{ needs.Dependencies.outputs.fparser_checkout_title }}
+        uses: actions/checkout@v4
+        with:
+          repository: "${{ needs.Dependencies.outputs.fparser_repo }}"
+          ref: "${{ needs.Dependencies.outputs.fparser_branch }}"
+          path: fparser
+
       - name: Install dependencies
         shell: sh
         run: |
@@ -449,21 +581,6 @@ jobs:
           mkdir build && cd build
           cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/opt
           make -j$NCPUS && make install
-
-      - name: Checkout CSXCAD.git
-        uses: actions/checkout@v4
-        with:
-          repository: "${{ github.repository_owner }}/CSXCAD"
-          path: CSXCAD
-          # checkout must be deep, not shallow.
-          # We need tags for "git describe", otherwise build fails.
-          fetch-depth: 0
-
-      - name: Checkout fparser.git
-        uses: actions/checkout@v4
-        with:
-          repository: "${{ github.repository_owner }}/fparser"
-          path: fparser
 
       - name: Build and install fparser
         run: |
@@ -538,6 +655,7 @@ jobs:
 
   FreeBSD:
     runs-on: ubuntu-latest
+    needs: Dependencies
 
     strategy:
       matrix:
@@ -557,23 +675,32 @@ jobs:
     name: "${{ matrix.machine.name }}"
 
     steps:
-      - name: Checkout fparser.git
-        uses: actions/checkout@v4
-        with:
-          repository: "${{ github.repository_owner }}/fparser"
-          path: fparser
-          # checkout must be deep, not shallow.
-          # We need tags for "git describe", otherwise build fails.
-          fetch-depth: 0
+      - name: Show checkout sources
+        run: |
+          echo "$FPARSER_CHECKOUT_TITLE"
+        env:
+          # convert template variables to shell variables to avoid arbitrary code injection
+          FPARSER_CHECKOUT_TITLE: ${{ needs.Dependencies.outputs.fparser_checkout_title }}
 
+      # When checking out repos, I recommend running actions/checkout
+      # as soon as possible before anything else, and in the reverse
+      # order, from the project repo to its dependencies. This reduces
+      # race conditions due to force pushes (they are harmless but
+      # annoying).
       - name: Checkout CSXCAD.git
         uses: actions/checkout@v4
         with:
-          repository: "${{ github.repository_owner }}/CSXCAD"
           path: CSXCAD
           # checkout must be deep, not shallow.
           # We need tags for "git describe", otherwise build fails.
           fetch-depth: 0
+
+      - name: ${{ needs.Dependencies.outputs.fparser_checkout_title }}
+        uses: actions/checkout@v4
+        with:
+          repository: "${{ needs.Dependencies.outputs.fparser_repo }}"
+          ref: "${{ needs.Dependencies.outputs.fparser_branch }}"
+          path: fparser
 
       - name: Test in FreeBSD ${{ matrix.machine.version }} ${{ matrix.machine.arch }}
         uses: cross-platform-actions/action@v0.26.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,7 +402,9 @@ jobs:
           echo "export NCPUS=$(python3 -c 'import os; print(os.cpu_count())')" >> ~/.zprofile
           echo 'export CXXFLAGS="-Wall -Wextra -Wno-error"' >> ~/.zprofile
 
-          brew install cmake hdf5 cgal vtk python3 python-setuptools numpy cython python-matplotlib
+          # already installed on the CI/CD system, disable to avoid warning fatigue
+          # brew install python3 cmake
+          brew install hdf5 cgal vtk python-setuptools numpy cython python-matplotlib
 
           # TinyXML has been disabled by Homebrew at it's unmaintained
           # since 2011, TinyXML2 is not API-compatible. As a stop-gap,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,13 @@ jobs:
 
     name: "${{ matrix.os.libc }}/Linux (${{ matrix.os.name }})"
 
+    env:
+      # Wno-error is needed because any third-party dependencies
+      # like compiler version changes or even Python libraries
+      # installed by pip can block the pipeline, this is not what
+      # we want.
+      CXXFLAGS: "-Wall -Wextra -Wno-error"
+
     steps:
       - name: Check for dockerenv file
         # bash is not installed on Alpine at this point
@@ -107,9 +114,6 @@ jobs:
       - name: Install dependencies
         shell: sh
         run: |
-          touch ~/.bash_profile  # set environmental variables here
-          echo 'export CXXFLAGS="-Wall -Wextra -Wno-error"' >> ~/.bash_profile
-
           if grep -q "ID=fedora" /etc/os-release; then
             dnf install -y git
             dnf install -y gcc gcc-c++ cmake git tinyxml-devel vtk-devel hdf5-devel \
@@ -285,7 +289,6 @@ jobs:
 
       - name: Build and install fparser
         run: |
-          source ~/.bash_profile
           cd $GITHUB_WORKSPACE/fparser
           mkdir build && cd build
           cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/opt
@@ -300,7 +303,6 @@ jobs:
           #
           # MPI may also fail, but this error is not fatal. The real error is often
           # the error above! There's no need to install MPI.
-          source ~/.bash_profile
           cd $GITHUB_WORKSPACE/CSXCAD
           mkdir build && cd build
           cmake ../ -DCMAKE_INSTALL_PREFIX=$HOME/opt
@@ -308,7 +310,6 @@ jobs:
 
       - name: Build and install CSXCAD Python module with --no-build-isolation
         run: |
-          source ~/.bash_profile
           cd $GITHUB_WORKSPACE/CSXCAD/python
           export CSXCAD_INSTALL_PATH="$HOME/opt"
 
@@ -330,20 +331,17 @@ jobs:
 
       - name: Smoketest CSXCAD Python module execution
         run: |
-          source ~/.bash_profile
           cd /
           python3 -c "import CSXCAD; print(CSXCAD.ContinuousStructure())"
           python3 -c "import CSXCAD; print(CSXCAD.__version__)"
 
       - name: Unittest CSXCAD Python module execution
         run: |
-          source ~/.bash_profile
           cd $GITHUB_WORKSPACE/CSXCAD/python/tests
           python3 -m unittest
 
       - name: Create Python venv and install dependencies
         run: |
-          source ~/.bash_profile
           cd ~/
 
           if grep -q "ID=ubuntu" /etc/os-release && \
@@ -375,7 +373,6 @@ jobs:
 
       - name: Build and install CSXCAD Python module in venv
         run: |
-          source ~/.bash_profile
           source ~/venv/bin/activate
           cd $GITHUB_WORKSPACE/CSXCAD/python
           export CSXCAD_INSTALL_PATH="$HOME/opt"
@@ -383,7 +380,6 @@ jobs:
 
       - name: Smoketest CSXCAD Python module execution in venv
         run: |
-          source ~/.bash_profile
           source ~/venv/bin/activate
           cd /
           python3 -c "import CSXCAD; print(CSXCAD.ContinuousStructure())"
@@ -391,7 +387,6 @@ jobs:
 
       - name: Unittest CSXCAD Python module execution in venv
         run: |
-          source ~/.bash_profile
           source ~/venv/bin/activate
           cd $GITHUB_WORKSPACE/CSXCAD/python/tests
           python3 -m unittest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ find_package(CGAL REQUIRED)
 INCLUDE_DIRECTORIES (${CGAL_INCLUDE_DIR})
 
 # CGAL may be complied as headers, or as shared objects, which we must link
-if (${CGAL_VERSION} VERSION_GREATER 5.0)
+if ("${CGAL_VERSION}" VERSION_GREATER 5.0)
     set(CSXCAD_CGAL_LIBRARIES CGAL::CGAL)
     message(STATUS "Found package CGAL v5+. Using version " ${CGAL_VERSION})
 else()
@@ -148,7 +148,7 @@ endif()
 
 # vtk
 find_package(VTK COMPONENTS vtkCommonCore NO_MODULE QUIET)
-if (${VTK_VERSION} VERSION_GREATER "9")
+if ("${VTK_VERSION}" VERSION_GREATER "9")
     find_package(VTK REQUIRED COMPONENTS IOGeometry IOPLY NO_MODULE REQUIRED)
 else()
     find_package(VTK REQUIRED COMPONENTS vtkIOGeometry vtkIOPLY NO_MODULE REQUIRED)

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "fafcc0e93bfba303e5e48790def745d27e6d449b",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": [
+    "boost",
+    "cgal",
+    "hdf5",
+    "tinyxml",
+    "vtk"
+  ]
+}


### PR DESCRIPTION
## Introduction

This Pull Request introduces two major new features and performs some housekeeping tasks to the CI/CD pipeline:

1. Add automatic dependent-repo resolution logic.

2. Test Windows / Visual Studio 2022 using MSVC and clang-cl.
    * vcpkg manifest files for automatic dependency installation.
    * cache compiled vcpkg packages using GitHub Actions cache.

3. Miscellaneous housekeeping changes.

Not implemented:

1. Unit tests and smoke tests on Windows.
2. Python extensions on Windows.

To be implement in the future.

## CI: Add automatic dependent repo resolution logic.

The openEMS Project is a multi-repo project. Changes frequently affect multiple repos, with changes depending on each other. Forking a repo also means all related repos must be forked together, creating a poor contribution experience, since the CI pipeline doesn't work properly for them.

This commit introduces automatic dependent-repo resolution logic to the CI/CD pipeline, with the following rules.

1. Want to develop a multi-repo change in CSXCAD and openEMS? Use the same branch name, they'll be tested together.

4. Want to send Pull Requests to both CSXCAD and openEMS? Use the same branch name in your fork, and open two individual Pull Requests against CSXCAD and openEMS. If both Pull Requests are opened, and the source branch name is the same, they'll be tested together.

5. Want to fork openEMS and develop it at the downstream? You can fork the only the repos you need. The CI/CD script automatically uses the project founder's repos as fall back for non-forked dependencies. You can override these dependencies by forking more repos.

### Owner-then-Founder Dependency Lookup

If a git commit is pushed into a repo, or if a repo has received a Pull Request from a contributor, to build this repo, we need to look for the repo's dependencies. We check all dependencies one by one. If the repo's owner also has dependent repo under their GitHub account. If it's the case, the owner's copy is used as the dependency. If it's not the case, the founder account thliebig's copy is used as the dependency.

This two-tier lookup solves several problems:

1. An experimenter can only fork openEMS without forking any dependencies. Since the CI/CD script falls back to the founder's repos for dependencies, their local repo's CI/CD works automatically. If they want to make a change to CSXCAD and openEMS at the same time, they only need to selectively fork CSXCAD, so that the "repo owner override" takes effect. At the same time, they can keep using the founder's fparser repo as a fallback without forking it.

2. Someone may send a Pull Request against a downstream fork itself, rather than the project founder. For example, I have a downstream openEMS fork named fasterEMS. If someone sends a Pull Request against my "fasterEMS/CSXCAD", my repo's CI/CD needs to use the same-owner repo "fasterEMS/fparser" as the dependency, not project founder's "thliebig/fparser".

### Pull-Request Ganging

If a Pull Request "pr_primary" is submitted against the upstream repo "repo_primary", we check whether the same contributor has also opened another Pull Request "pr_dependency" against our dependency "repo_dependency", and whether both Pull Requests uses the same source branch name, such as "feature". If both conditions are met, we can say that two Pull Requests are "ganged", they are tested by CI/CD together. When testing "pr_primary" at "repo_primary", instead of using default repos as dependencies, we checkout the merge commit of "pr_secondary" at the "repo_secondary" as its dependency.

For more than 2 repos, the same "ganged PR" logic also applies.

If Pull-Request Ganging is activated, a warning is generated in the "Annotations" panel of the GitHub Actions Summary page, reminding developers to merge the dependent PR first before the main PR.

### Branch Ganging

If a git commit is submitted to a non-default branch "feature" of repo "repo_primary", we check whether our dependency "repo_dependency" also has a branch named "feature".

If this condition is met, we can say that two repo branches are "ganged", they are tested by CI/CD together. When testing the branch "feature" of "repo_primary", instead of using default branch "master" of "repo_dependency" as the dependency, we checkout the branch "feature" the "repo_dependency" instead.

This allows testing multi-repo features together while it's in development. For more than 2 repos, the same "ganged branches" logic also applies.

If Branch Ganging is activated, a warning is generated in the "Annotations" panel of the GitHub Actions Summary page, reminding developers that a different branch of the dependent repo is used for this test.

### Implementation Details

This commit adds a new CI job called "Resolve Repo Dependencies", which is executed before all other jobs. This job calls the Python script "scripts/resolve_dependent_repos.py", which uses GitHub Actions variables and GitHub APIs to find the needed dependencies according to the conditions and contexts explained above.

After the script finishes, it generates several output variables that contain the repoes and branches of all dependencies. These output variables are passed using the shell variable "$GITHUB_OUTPUT" (provided by GitHub Actions), later, all other jobs use these variable as their inputs for the "actions/checkout" steps.

## vcpkg

### vcpkg: add manifest for managing Windows dependencies.
    
This commit introduces a project manifest for managing Windows dependencies using vcpkg, the modern C/C++ package manager for Windows development.
    
Although vcpkg is a Microsoft product, it's a free and open source package manager. In principle, vcpkg can also manage dependencies and even make binary releases on Unix-like systems, but this use case is untested and unsupported. Use at one's own risks. Currently, the use case is strictly for auto-building dependencies on Windows.
    
Note: since we have to maintain the vcpkg pipeline anyway, perhaps it does make sense to reuse vcpkg for releasing binary packages for both Windows and Unix-like systems in the future, but this remains a speculative idea for now.

### CI: Windows MSVC/clang-cl Test using Visual Studio 2022.

This commit introduces Continuous Integration for Windows with MSVC/clang-cl shipped in Visual Studio 2022.
    
vcpkg is used to automatically build all dependencies from source, with the advantage of full automation, latest upstream version, perfect binary compatibility, and customizable build flags.
    
However, the full source build takes a long time (like using Gentoo Portage or MacPorts), in this case, 2 hours. A vcpkg binary cache is used to speedup iterative development. GitHub Actions cache is immutable, we can't modify existing cache, so we use a last-recently logic: Before each run, the last-written cache with a given prefix is restored. After each run, a new cache with the same prefix and a different suffix is submitted to GitHub. It's GitHub's responsibility to delete old cache if 7 days have passed or after the total size exceeds 10 GiB.

## Housekeeping

### CI: use GitHub Actions env block, not bash_profile.
    
For the Linux matrix, use GitHub Actions native "env" block to define CXXFLAGS, not bash_profile.

### CI: Don't install python3 and cmake on macOS.

Homebrew always warns that python3 and cmake are already installed, this causes warning fatigue in the GitHub Actions Summary's "Annotations" panel, developers may miss other useful warnings.

### CMakeLists.txt: quote VTK_VERSION and CGAL_VERSION

If `VTK_VERSION` is an empty string (because VTK is not installed), the statement `if (${VTK_VERSION} VERSION_GREATER "9")` is evaluated as `if (VERSION_GREATER "9")`, generating the following misleading and confusing syntax error:
    
        CMake Error at CMakeLists.txt:151 (if):
          if given arguments:
    
            "VERSION_GREATER" "9"
    
          Unknown arguments specified
    
Quote `VTK_VERSION` to avoid the error. We do the same for `CGAL_VERSION` for consistency (although `CGAL_VERSION` shouldn't be affected by the same problem since errors are not ignored)