### PR TITLE
CI: fix useless warnings, skip default branch when resolving dependencies.

### DIFF
--- a/.github/scripts/resolve_dependent_repos.py
+++ b/.github/scripts/resolve_dependent_repos.py
@@ -140,7 +140,10 @@ def determine_repo_dependency(project):
     # same name as the current repo branch, use that branch instead.
     # This allowing testing multi-repo features.
     for repo in repo_dependency:
-        if reponame_has_branch(owner, repo["name"], src_branch):
+        if (
+            repo["branch"] != src_branch and
+            reponame_has_branch(owner, repo["name"], src_branch)
+        ):
             repo["branch"] = src_branch
 
             # only warn dependencies, not current repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,10 +815,6 @@ jobs:
       VCPKG_ASSET_CACHE_PATH: "${{ github.workspace }}/vcpkg-cache/asset"
       X_VCPKG_ASSET_SOURCES: "x-azurl,file://${{ github.workspace }}/vcpkg-cache/asset,readwrite"
 
-    # allow this job to create and modify vcpkg packages for binary cache
-    permissions:
-      packages: write
-
     name: "Windows (${{ matrix.toolchain.name }}, latest)"
 
     steps:


### PR DESCRIPTION
##  CI: skip default branch when resolving dependencies.

The dependency resolution logic resolve_dependent_repos.py currently tries to apply the "ganged branch" logic even for the default branch, creating useless and misleading warnings:

    * thliebig/CSXCAD: different branch "master" used
      repo thliebig/CSXCAD branch master is used instead of the default branch.

    * thliebig/fparser: different branch "master" used
      repo thliebig/fparser branch master is used instead of the default branch.

Avoid applying "branch ganging" if the dependency is already on the branch we're switching to.

## CI: remove unused "permissions: packages: write"

The option `permissions: packages: write` was used to enable NuGet repository for vcpkg caching, but eventually this caching method was not used due to my security concerns of cache poisoning. It's unclear whether a third-party contributor can write arbitrary packages to the NuGet repository. Thus, regular GitHub file caching via "actions/cache" was used (which is isolated per branch, by default, it's not possible to overwrite the trusted "master" branch caching just by opening a PR).

Remove unused `permissions: packages: write`.