### PR TITLE
[ci] Update GitHub Actions to latest major release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Resolve repo dependencies
         id: resolve-dependencies
@@ -191,7 +191,7 @@ jobs:
       # annoying).
       - if: ${{ ! matrix.os.ancient }}
         name: Checkout CSXCAD.git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: CSXCAD
           # checkout must be deep, not shallow.
@@ -514,7 +514,7 @@ jobs:
       # race conditions due to force pushes (they are harmless but
       # annoying).
       - name: Checkout CSXCAD.git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: CSXCAD
           # checkout must be deep, not shallow.
@@ -522,7 +522,7 @@ jobs:
           fetch-depth: 0
 
       - name: ${{ needs.Dependencies.outputs.fparser_checkout_title }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "${{ needs.Dependencies.outputs.fparser_repo }}"
           ref: "${{ needs.Dependencies.outputs.fparser_branch }}"
@@ -688,7 +688,7 @@ jobs:
       # race conditions due to force pushes (they are harmless but
       # annoying).
       - name: Checkout CSXCAD.git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: CSXCAD
           # checkout must be deep, not shallow.
@@ -696,14 +696,14 @@ jobs:
           fetch-depth: 0
 
       - name: ${{ needs.Dependencies.outputs.fparser_checkout_title }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "${{ needs.Dependencies.outputs.fparser_repo }}"
           ref: "${{ needs.Dependencies.outputs.fparser_branch }}"
           path: fparser
 
       - name: Test in FreeBSD ${{ matrix.machine.version }} ${{ matrix.machine.arch }}
-        uses: cross-platform-actions/action@v0.26.0
+        uses: cross-platform-actions/action@v1
         with:
           cpu_count: 4
           architecture: ${{ matrix.machine.arch }}
@@ -831,7 +831,7 @@ jobs:
       # race conditions due to force pushes (they are harmless but
       # annoying).
       - name: Checkout CSXCAD.git
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: CSXCAD
           # checkout must be deep, not shallow.
@@ -839,7 +839,7 @@ jobs:
           fetch-depth: 0
 
       - name: ${{ needs.Dependencies.outputs.fparser_checkout_title }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: "${{ needs.Dependencies.outputs.fparser_repo }}"
           ref: "${{ needs.Dependencies.outputs.fparser_branch }}"


### PR DESCRIPTION
Fix deprecation warnings for Node20.js which will stop working in June.